### PR TITLE
[LLSC-38] Add extensions recs and settings json to backend folder

### DIFF
--- a/backend/.vscode/extensions.json
+++ b/backend/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "charliermarsh.ruff",
+    "njpwerner.autodocstring",
+    "ckolkman.vscode-postgres"
+  ]
+}

--- a/backend/.vscode/settings.json
+++ b/backend/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
+}


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Add VSCode settings json to backend](https://www.notion.so/uwblueprintexecs/Add-settings-json-for-backend-13810f3fb1dc8060a82df344193e98ef?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
Adding settings json for people who work predominantly in the backend folder, ie. their workspace is `/backend`. The language server isn't able to pick up the python executable in `.venv` on `/backend` within this json file without having it included in `/backend`.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to VSCode and open the project from `/backend`.
2. Check if the interpreter is set to `.venv/bin/python` and you're able to see autocomplete and hover text and signature information.


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
