### PR TITLE
[LLSC-53] Replace alembic migrate on startup with SQLAchemy create table

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,6 +1,3 @@
-from alembic import command
-from alembic.config import Config
-
 # Make sure all models are here to reflect all current models
 # when autogenerating new migration
 from .Base import Base
@@ -9,9 +6,3 @@ from .User import User
 
 # Used to avoid import errors for the models
 __all__ = ["Base", "User", "Role"]
-
-
-def run_migrations():
-    alembic_cfg = Config("alembic.ini")
-    # Emulates `alembic upgrade head` to migrate up to latest revision
-    command.upgrade(alembic_cfg, "head")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,3 +1,7 @@
+import os
+
+from sqlalchemy import create_engine
+
 # Make sure all models are here to reflect all current models
 # when autogenerating new migration
 from .Base import Base
@@ -6,3 +10,8 @@ from .User import User
 
 # Used to avoid import errors for the models
 __all__ = ["Base", "User", "Role"]
+
+
+def create_tables():
+    engine = create_engine(os.getenv("POSTGRES_DATABASE_URL"))
+    Base.metadata.create_all(bind=engine)

--- a/backend/app/server.py
+++ b/backend/app/server.py
@@ -5,6 +5,7 @@ from typing import Union
 from dotenv import load_dotenv
 from fastapi import FastAPI
 
+from app.models import create_tables
 from app.routes import email
 
 load_dotenv()
@@ -19,6 +20,7 @@ log = logging.getLogger("uvicorn")
 @asynccontextmanager
 async def lifespan(_: FastAPI):
     log.info("Starting up...")
+    create_tables()
     initialize_firebase()
     yield
     log.info("Shutting down...")

--- a/backend/app/server.py
+++ b/backend/app/server.py
@@ -10,7 +10,6 @@ from app.routes import email
 load_dotenv()
 
 # we need to load env variables before initialization code runs
-from . import models  # noqa: E402
 from .routes import user  # noqa: E402
 from .utilities.firebase_init import initialize_firebase  # noqa: E402
 
@@ -20,7 +19,6 @@ log = logging.getLogger("uvicorn")
 @asynccontextmanager
 async def lifespan(_: FastAPI):
     log.info("Starting up...")
-    models.run_migrations()
     initialize_firebase()
     yield
     log.info("Shutting down...")


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Remove Alembic migration on startup](https://www.notion.so/uwblueprintexecs/Remove-Alembic-migration-on-startup-15610f3fb1dc80ceb62aec85a534061f?pvs=4)

The `alembic.ini` and `env.py` config is taking control of the logging system when running `run_migrations` using `alembic.command`
https://github.com/uwblueprint/llsc/blob/b74cc476e8400fa6534ca3e46b650bd439043112/backend/app/models/__init__.py#L14, meaning errors that should normally be displayed are not being displayed. 

This is a bigger priority for productivity to maintain over worrying about up-to-date database migrations, so we need to remove the current system of making sure databases are up to date.

We will replace this with SQLAlchemy create table, which creates tables based on the models, not the migrations. We should conduct a further investigation of whether migration-based table management will be necessary.

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Clear docker volume for Postgres database
2. Start up server `pdm run dev`
3. Check if API can be hit and all tables are correct


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
