### PR TITLE
Add password checks for registration

### DIFF
--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -53,7 +53,7 @@ class UserCreateRequest(UserBase):
     Request schema for user creation with conditional password validation
     """
 
-    password: Optional[str] = Field(None, min_length=8)
+    password: Optional[str] = Field(None)
     auth_id: Optional[str] = Field(None)
     signup_method: SignUpMethod = Field(default=SignUpMethod.PASSWORD)
 
@@ -65,12 +65,18 @@ class UserCreateRequest(UserBase):
             raise ValueError("Password is required for password signup")
 
         if password:
-            if not any(char.isdigit() for char in password):
-                raise ValueError("Password must contain at least one digit")
+            errors = []
+            if len(password) < 8:
+                errors.append("be at least 8 characters long")
             if not any(char.isupper() for char in password):
-                raise ValueError("Password must contain at least one uppercase letter")
+                errors.append("contain at least one uppercase letter")
             if not any(char.islower() for char in password):
-                raise ValueError("Password must contain at least one lowercase letter")
+                errors.append("contain at least one lowercase letter")
+            if not any(char in "!@#$%^&*" for char in password):
+                errors.append("contain at least one special character (!, @, #, $, %, ^, &, or *)")
+
+            if errors:
+                raise ValueError(f"Password must {', '.join(errors)}")
 
         return password
 

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -67,16 +67,16 @@ class UserCreateRequest(UserBase):
         if password:
             errors = []
             if len(password) < 8:
-                errors.append("be at least 8 characters long")
+                errors.append("Password must be at least 8 characters long")
             if not any(char.isupper() for char in password):
-                errors.append("contain at least one uppercase letter")
+                errors.append("Password must contain at least one uppercase letter")
             if not any(char.islower() for char in password):
-                errors.append("contain at least one lowercase letter")
+                errors.append("Password must contain at least one lowercase letter")
             if not any(char in "!@#$%^&*" for char in password):
-                errors.append("contain at least one special character (!, @, #, $, %, ^, &, or *)")
+                errors.append("Password must contain at least one special character (!, @, #, $, %, ^, &, or *)")
 
             if errors:
-                raise ValueError(f"Password must {', '.join(errors)}")
+                raise ValueError(errors)
 
         return password
 

--- a/backend/tests/unit/test_user_schema.py
+++ b/backend/tests/unit/test_user_schema.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
-from app.schemas.user import UserCreateRequest, UserRole, SignUpMethod
+from app.schemas.user import SignUpMethod, UserCreateRequest, UserRole
 
 
 class TestUserCreateRequestPasswordValidation:
@@ -11,13 +11,13 @@ class TestUserCreateRequestPasswordValidation:
         """Test that a valid password passes validation"""
         user_data = {
             "first_name": "Test",
-            "last_name": "User", 
+            "last_name": "User",
             "email": "test@example.com",
             "password": "ValidPass123!",
             "role": UserRole.PARTICIPANT,
             "signup_method": SignUpMethod.PASSWORD,
         }
-        
+
         # Should not raise any exception
         user_request = UserCreateRequest(**user_data)
         assert user_request.password == "ValidPass123!"
@@ -27,18 +27,18 @@ class TestUserCreateRequestPasswordValidation:
         user_data = {
             "first_name": "Test",
             "last_name": "User",
-            "email": "test@example.com", 
+            "email": "test@example.com",
             "password": "short1!",  # Only 7 characters
             "role": UserRole.PARTICIPANT,
             "signup_method": SignUpMethod.PASSWORD,
         }
-        
+
         with pytest.raises(ValidationError) as exc_info:
             UserCreateRequest(**user_data)
-        
+
         # Check that the error message contains the expected validation message
         error_msg = str(exc_info.value)
-        assert "be at least 8 characters long" in error_msg
+        assert "Password must be at least 8 characters long" in error_msg
 
     def test_password_validation_missing_uppercase(self):
         """Test that password without uppercase letter fails validation"""
@@ -50,12 +50,12 @@ class TestUserCreateRequestPasswordValidation:
             "role": UserRole.PARTICIPANT,
             "signup_method": SignUpMethod.PASSWORD,
         }
-        
+
         with pytest.raises(ValidationError) as exc_info:
             UserCreateRequest(**user_data)
-        
+
         error_msg = str(exc_info.value)
-        assert "contain at least one uppercase letter" in error_msg
+        assert "Password must contain at least one uppercase letter" in error_msg
 
     def test_password_validation_missing_lowercase(self):
         """Test that password without lowercase letter fails validation"""
@@ -67,12 +67,12 @@ class TestUserCreateRequestPasswordValidation:
             "role": UserRole.PARTICIPANT,
             "signup_method": SignUpMethod.PASSWORD,
         }
-        
+
         with pytest.raises(ValidationError) as exc_info:
             UserCreateRequest(**user_data)
-        
+
         error_msg = str(exc_info.value)
-        assert "contain at least one lowercase letter" in error_msg
+        assert "Password must contain at least one lowercase letter" in error_msg
 
     def test_password_validation_missing_special_character(self):
         """Test that password without special character fails validation"""
@@ -84,32 +84,32 @@ class TestUserCreateRequestPasswordValidation:
             "role": UserRole.PARTICIPANT,
             "signup_method": SignUpMethod.PASSWORD,
         }
-        
+
         with pytest.raises(ValidationError) as exc_info:
             UserCreateRequest(**user_data)
-        
+
         error_msg = str(exc_info.value)
-        assert "contain at least one special character" in error_msg
+        assert "Password must contain at least one special character" in error_msg
 
     def test_password_validation_multiple_errors(self):
         """Test that password with multiple issues returns all errors"""
         user_data = {
-            "first_name": "Test", 
+            "first_name": "Test",
             "last_name": "User",
             "email": "test@example.com",
             "password": "short",  # Too short, no uppercase, no special char
             "role": UserRole.PARTICIPANT,
             "signup_method": SignUpMethod.PASSWORD,
         }
-        
+
         with pytest.raises(ValidationError) as exc_info:
             UserCreateRequest(**user_data)
-        
+
         error_msg = str(exc_info.value)
         # Should contain multiple validation errors
-        assert "be at least 8 characters long" in error_msg
-        assert "contain at least one uppercase letter" in error_msg
-        assert "contain at least one special character" in error_msg
+        assert "Password must be at least 8 characters long" in error_msg
+        assert "Password must contain at least one uppercase letter" in error_msg
+        assert "Password must contain at least one special character" in error_msg
 
     def test_password_validation_google_signup_no_password_required(self):
         """Test that Google signup doesn't require password validation"""
@@ -121,7 +121,7 @@ class TestUserCreateRequestPasswordValidation:
             "role": UserRole.PARTICIPANT,
             "signup_method": SignUpMethod.GOOGLE,
         }
-        
+
         # Should not raise any exception for Google signup
         user_request = UserCreateRequest(**user_data)
         assert user_request.password is None
@@ -131,13 +131,13 @@ class TestUserCreateRequestPasswordValidation:
         # Test with exactly 8 characters
         user_data = {
             "first_name": "Test",
-            "last_name": "User", 
+            "last_name": "User",
             "email": "test@example.com",
             "password": "MinPass1!",  # Exactly 8 chars, meets all requirements
             "role": UserRole.PARTICIPANT,
             "signup_method": SignUpMethod.PASSWORD,
         }
-        
+
         # Should not raise any exception
         user_request = UserCreateRequest(**user_data)
         assert user_request.password == "MinPass1!"
@@ -145,17 +145,17 @@ class TestUserCreateRequestPasswordValidation:
     def test_password_validation_all_special_characters(self):
         """Test that all allowed special characters work"""
         special_chars = ["!", "@", "#", "$", "%", "^", "&", "*"]
-        
+
         for char in special_chars:
             user_data = {
                 "first_name": "Test",
                 "last_name": "User",
-                "email": "test@example.com", 
+                "email": "test@example.com",
                 "password": f"ValidPass1{char}",
                 "role": UserRole.PARTICIPANT,
                 "signup_method": SignUpMethod.PASSWORD,
             }
-            
+
             # Should not raise any exception
             user_request = UserCreateRequest(**user_data)
-            assert user_request.password == f"ValidPass1{char}" 
+            assert user_request.password == f"ValidPass1{char}"

--- a/backend/tests/unit/test_user_schema.py
+++ b/backend/tests/unit/test_user_schema.py
@@ -1,0 +1,161 @@
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.user import UserCreateRequest, UserRole, SignUpMethod
+
+
+class TestUserCreateRequestPasswordValidation:
+    """Test password validation in UserCreateRequest schema"""
+
+    def test_password_validation_success_valid_password(self):
+        """Test that a valid password passes validation"""
+        user_data = {
+            "first_name": "Test",
+            "last_name": "User", 
+            "email": "test@example.com",
+            "password": "ValidPass123!",
+            "role": UserRole.PARTICIPANT,
+            "signup_method": SignUpMethod.PASSWORD,
+        }
+        
+        # Should not raise any exception
+        user_request = UserCreateRequest(**user_data)
+        assert user_request.password == "ValidPass123!"
+
+    def test_password_validation_too_short(self):
+        """Test that password less than 8 characters fails validation"""
+        user_data = {
+            "first_name": "Test",
+            "last_name": "User",
+            "email": "test@example.com", 
+            "password": "short1!",  # Only 7 characters
+            "role": UserRole.PARTICIPANT,
+            "signup_method": SignUpMethod.PASSWORD,
+        }
+        
+        with pytest.raises(ValidationError) as exc_info:
+            UserCreateRequest(**user_data)
+        
+        # Check that the error message contains the expected validation message
+        error_msg = str(exc_info.value)
+        assert "be at least 8 characters long" in error_msg
+
+    def test_password_validation_missing_uppercase(self):
+        """Test that password without uppercase letter fails validation"""
+        user_data = {
+            "first_name": "Test",
+            "last_name": "User",
+            "email": "test@example.com",
+            "password": "lowercase123!",  # No uppercase
+            "role": UserRole.PARTICIPANT,
+            "signup_method": SignUpMethod.PASSWORD,
+        }
+        
+        with pytest.raises(ValidationError) as exc_info:
+            UserCreateRequest(**user_data)
+        
+        error_msg = str(exc_info.value)
+        assert "contain at least one uppercase letter" in error_msg
+
+    def test_password_validation_missing_lowercase(self):
+        """Test that password without lowercase letter fails validation"""
+        user_data = {
+            "first_name": "Test",
+            "last_name": "User",
+            "email": "test@example.com",
+            "password": "UPPERCASE123!",  # No lowercase
+            "role": UserRole.PARTICIPANT,
+            "signup_method": SignUpMethod.PASSWORD,
+        }
+        
+        with pytest.raises(ValidationError) as exc_info:
+            UserCreateRequest(**user_data)
+        
+        error_msg = str(exc_info.value)
+        assert "contain at least one lowercase letter" in error_msg
+
+    def test_password_validation_missing_special_character(self):
+        """Test that password without special character fails validation"""
+        user_data = {
+            "first_name": "Test",
+            "last_name": "User",
+            "email": "test@example.com",
+            "password": "NoSpecial123",  # No special characters
+            "role": UserRole.PARTICIPANT,
+            "signup_method": SignUpMethod.PASSWORD,
+        }
+        
+        with pytest.raises(ValidationError) as exc_info:
+            UserCreateRequest(**user_data)
+        
+        error_msg = str(exc_info.value)
+        assert "contain at least one special character" in error_msg
+
+    def test_password_validation_multiple_errors(self):
+        """Test that password with multiple issues returns all errors"""
+        user_data = {
+            "first_name": "Test", 
+            "last_name": "User",
+            "email": "test@example.com",
+            "password": "short",  # Too short, no uppercase, no special char
+            "role": UserRole.PARTICIPANT,
+            "signup_method": SignUpMethod.PASSWORD,
+        }
+        
+        with pytest.raises(ValidationError) as exc_info:
+            UserCreateRequest(**user_data)
+        
+        error_msg = str(exc_info.value)
+        # Should contain multiple validation errors
+        assert "be at least 8 characters long" in error_msg
+        assert "contain at least one uppercase letter" in error_msg
+        assert "contain at least one special character" in error_msg
+
+    def test_password_validation_google_signup_no_password_required(self):
+        """Test that Google signup doesn't require password validation"""
+        user_data = {
+            "first_name": "Test",
+            "last_name": "User",
+            "email": "test@example.com",
+            # No password provided
+            "role": UserRole.PARTICIPANT,
+            "signup_method": SignUpMethod.GOOGLE,
+        }
+        
+        # Should not raise any exception for Google signup
+        user_request = UserCreateRequest(**user_data)
+        assert user_request.password is None
+
+    def test_password_validation_edge_cases(self):
+        """Test edge cases for password validation"""
+        # Test with exactly 8 characters
+        user_data = {
+            "first_name": "Test",
+            "last_name": "User", 
+            "email": "test@example.com",
+            "password": "MinPass1!",  # Exactly 8 chars, meets all requirements
+            "role": UserRole.PARTICIPANT,
+            "signup_method": SignUpMethod.PASSWORD,
+        }
+        
+        # Should not raise any exception
+        user_request = UserCreateRequest(**user_data)
+        assert user_request.password == "MinPass1!"
+
+    def test_password_validation_all_special_characters(self):
+        """Test that all allowed special characters work"""
+        special_chars = ["!", "@", "#", "$", "%", "^", "&", "*"]
+        
+        for char in special_chars:
+            user_data = {
+                "first_name": "Test",
+                "last_name": "User",
+                "email": "test@example.com", 
+                "password": f"ValidPass1{char}",
+                "role": UserRole.PARTICIPANT,
+                "signup_method": SignUpMethod.PASSWORD,
+            }
+            
+            # Should not raise any exception
+            user_request = UserCreateRequest(**user_data)
+            assert user_request.password == f"ValidPass1{char}" 

--- a/frontend/src/pages/participant-form.tsx
+++ b/frontend/src/pages/participant-form.tsx
@@ -104,120 +104,111 @@ export function ParticipantFormPage() {
             Let&apos;s start by creating an account.
           </Text>
           <form onSubmit={handleSubmit}>
-            <Box mb={4}>
-              <Field
-                label={
-                  <span
-                    style={{
-                      color: fieldGray,
-                      fontWeight: 600,
-                      fontSize: 14,
-                      fontFamily: 'Open Sans, sans-serif',
-                    }}
-                  >
-                    Email
-                  </span>
-                }
-              >
-                <InputGroup w="100%">
-                  <Input
-                    type="email"
-                    placeholder="john.doe@gmail.com"
-                    required
-                    autoComplete="email"
-                    w="100%"
-                    maxW="518px"
-                    fontFamily="'Open Sans', sans-serif"
-                    fontWeight={400}
-                    fontSize={14}
-                    color={fieldGray}
-                    bg="white"
-                    borderColor="#D5D7DA"
-                    _placeholder={{ color: '#A0AEC0', fontWeight: 400 }}
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                  />
-                </InputGroup>
-              </Field>
-            </Box>
-            <Box mb={4}>
-              <Field
-                label={
-                  <span
-                    style={{
-                      color: fieldGray,
-                      fontWeight: 600,
-                      fontSize: 14,
-                      fontFamily: 'Open Sans, sans-serif',
-                    }}
-                  >
-                    Password
-                  </span>
-                }
-              >
-                <InputGroup w="100%">
-                  <Input
-                    type="password"
-                    placeholder=""
-                    required
-                    autoComplete="new-password"
-                    w="100%"
-                    maxW="518px"
-                    fontFamily="'Open Sans', sans-serif"
-                    fontWeight={400}
-                    fontSize={14}
-                    color={fieldGray}
-                    bg="white"
-                    borderColor="#D5D7DA"
-                    _placeholder={{ color: '#A0AEC0', fontWeight: 400 }}
-                    value={password}
-                    onChange={(e) => {
-                      setPassword(e.target.value);
-                      // Clear password validation errors when user starts typing
-                      if (passwordValidationErrors.length > 0) {
-                        setPasswordValidationErrors([]);
-                      }
-                    }}
-                  />
-                </InputGroup>
-              </Field>
-            </Box>
-            <Box mb={4}>
-              <Field
-                label={
-                  <span
-                    style={{
-                      color: fieldGray,
-                      fontWeight: 600,
-                      fontSize: 14,
-                      fontFamily: 'Open Sans, sans-serif',
-                    }}
-                  >
-                    Confirm Password
-                  </span>
-                }
-              >
-                <InputGroup w="100%">
-                  <Input
-                    type="password"
-                    placeholder=""
-                    required
-                    autoComplete="new-password"
-                    w="100%"
-                    maxW="518px"
-                    fontFamily="'Open Sans', sans-serif"
-                    fontWeight={400}
-                    fontSize={14}
-                    color={fieldGray}
-                    bg="white"
-                    borderColor="#D5D7DA"
-                    _placeholder={{ color: '#A0AEC0', fontWeight: 400 }}
-                    value={confirmPassword}
-                    onChange={(e) => setConfirmPassword(e.target.value)}
-                  />
-                </InputGroup>
-              </Field>
-            </Box>
+            <Field
+              label={
+                <span
+                  style={{
+                    color: fieldGray,
+                    fontWeight: 600,
+                    fontSize: 14,
+                    fontFamily: 'Open Sans, sans-serif',
+                  }}
+                >
+                  Email
+                </span>
+              }
+              mb={4}
+            >
+              <InputGroup w="100%">
+                <Input
+                  type="email"
+                  placeholder="john.doe@gmail.com"
+                  required
+                  autoComplete="email"
+                  w="100%"
+                  maxW="518px"
+                  fontFamily="'Open Sans', sans-serif"
+                  fontWeight={400}
+                  fontSize={14}
+                  color={fieldGray}
+                  bg="white"
+                  borderColor="#D5D7DA"
+                  _placeholder={{ color: '#A0AEC0', fontWeight: 400 }}
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                />
+              </InputGroup>
+            </Field>
+            <Field
+              label={
+                <span
+                  style={{
+                    color: fieldGray,
+                    fontWeight: 600,
+                    fontSize: 14,
+                    fontFamily: 'Open Sans, sans-serif',
+                  }}
+                >
+                  Password
+                </span>
+              }
+              mb={4}
+            >
+              <InputGroup w="100%">
+                <Input
+                  type="password"
+                  placeholder=""
+                  required
+                  autoComplete="new-password"
+                  w="100%"
+                  maxW="518px"
+                  fontFamily="'Open Sans', sans-serif"
+                  fontWeight={400}
+                  fontSize={14}
+                  color={fieldGray}
+                  bg="white"
+                  borderColor="#D5D7DA"
+                  _placeholder={{ color: '#A0AEC0', fontWeight: 400 }}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                />
+              </InputGroup>
+            </Field>
+            <Field
+              label={
+                <span
+                  style={{
+                    color: fieldGray,
+                    fontWeight: 600,
+                    fontSize: 14,
+                    fontFamily: 'Open Sans, sans-serif',
+                  }}
+                >
+                  Confirm Password
+                </span>
+              }
+              mb={4}
+            >
+              <InputGroup w="100%">
+                <Input
+                  type="password"
+                  placeholder=""
+                  required
+                  autoComplete="new-password"
+                  w="100%"
+                  maxW="518px"
+                  fontFamily="'Open Sans', sans-serif"
+                  fontWeight={400}
+                  fontSize={14}
+                  color={fieldGray}
+                  bg="white"
+                  borderColor="#D5D7DA"
+                  _placeholder={{ color: '#A0AEC0', fontWeight: 400 }}
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                />
+              </InputGroup>
+            </Field>
 
             {/* Password Requirements - Only show when there are validation errors */}
             {passwordValidationErrors.length > 0 && (


### PR DESCRIPTION
## Notion ticket link
No link

## Implementation description
The backend user schema was modified to return an array of requirements that the password does not meet rather than just raising the first one, with updated requirements as well. The authApiClient was modified to handle 422 errors and parse this list of errors. The participant form frontend was modified check if there is an error before running `router.push()`, and to loop over the errors to display the requirement list. In the future we can make this change to admin page as well.

## Steps to test
On the registration page enter a password which does not fit the requirements. Instead of allowing you to proceed, it should show a checklist of requirements the password must meet. This should match the figma design: https://www.figma.com/design/HhFPmxFewSCBLGkIt9RZen/LLSC-Main-Design-File?node-id=6082-14924&t=xlyQNnm2i6cO0ct6-0

### What it looks like
![Image 2025-09-21 at 11 53 PM](https://github.com/user-attachments/assets/9c6b335b-00d6-44f3-83a5-27e03570124f)

### Backend tests
Tests in `user_schema_test.py` handle password requirement logic and all of them should pass
![Image 2025-09-22 at 11 18 AM](https://github.com/user-attachments/assets/8c1c24a6-46d0-4512-89a5-88bef6081572)

## What should reviewers focus on?


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
