### PR TITLE
opt out task created in admin

### DIFF
--- a/backend/app/models/Task.py
+++ b/backend/app/models/Task.py
@@ -15,6 +15,7 @@ class TaskType(str, PyEnum):
     VOLUNTEER_APP_REVIEW = "volunteer_app_review"
     PROFILE_UPDATE = "profile_update"
     MATCHING = "matching"
+    USER_OPT_OUT = "user_opt_out"
 
 
 class TaskPriority(str, PyEnum):

--- a/backend/app/schemas/task.py
+++ b/backend/app/schemas/task.py
@@ -20,6 +20,7 @@ class TaskType(str, Enum):
     VOLUNTEER_APP_REVIEW = "volunteer_app_review"
     PROFILE_UPDATE = "profile_update"
     MATCHING = "matching"
+    USER_OPT_OUT = "user_opt_out"
 
 
 class TaskPriority(str, Enum):

--- a/backend/app/services/implementations/user_service.py
+++ b/backend/app/services/implementations/user_service.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 from typing import List
 from uuid import UUID
 
@@ -18,6 +19,9 @@ from app.models import (
     RankingPreference,
     Role,
     Task,
+    TaskPriority,
+    TaskStatus,
+    TaskType,
     Treatment,
     User,
     UserData,
@@ -234,6 +238,19 @@ class UserService(IUserService):
                 raise HTTPException(status_code=404, detail="User not found")
 
             db_user.active = False
+
+            # Create a User Opt Out task for admin visibility (start and end date = day of opt-out)
+            opt_out_time = datetime.utcnow()
+            opt_out_task = Task(
+                participant_id=db_user.id,
+                type=TaskType.USER_OPT_OUT,
+                priority=TaskPriority.NO_STATUS,
+                status=TaskStatus.PENDING,
+                start_date=opt_out_time,
+                end_date=opt_out_time,
+            )
+            self.db.add(opt_out_task)
+
             self.db.commit()
         except ValueError:
             raise HTTPException(status_code=400, detail="Invalid user ID format")

--- a/frontend/src/APIClients/taskAPIClient.ts
+++ b/frontend/src/APIClients/taskAPIClient.ts
@@ -6,7 +6,12 @@ export interface BackendTask {
   participantName: string | null;
   participantEmail: string | null;
   participantRoleId: number | null;
-  type: 'intake_form_review' | 'volunteer_app_review' | 'profile_update' | 'matching' | 'user_opt_out';
+  type:
+    | 'intake_form_review'
+    | 'volunteer_app_review'
+    | 'profile_update'
+    | 'matching'
+    | 'user_opt_out';
   priority: 'no_status' | 'low' | 'medium' | 'high';
   status: 'pending' | 'in_progress' | 'completed';
   assigneeId: string | null;
@@ -26,7 +31,12 @@ export interface TaskListResponse {
 
 export interface UpdateTaskRequest {
   participantId?: string;
-  type?: 'intake_form_review' | 'volunteer_app_review' | 'profile_update' | 'matching' | 'user_opt_out';
+  type?:
+    | 'intake_form_review'
+    | 'volunteer_app_review'
+    | 'profile_update'
+    | 'matching'
+    | 'user_opt_out';
   priority?: 'no_status' | 'low' | 'medium' | 'high';
   status?: 'pending' | 'in_progress' | 'completed';
   assigneeId?: string | null;

--- a/frontend/src/APIClients/taskAPIClient.ts
+++ b/frontend/src/APIClients/taskAPIClient.ts
@@ -6,7 +6,7 @@ export interface BackendTask {
   participantName: string | null;
   participantEmail: string | null;
   participantRoleId: number | null;
-  type: 'intake_form_review' | 'volunteer_app_review' | 'profile_update' | 'matching';
+  type: 'intake_form_review' | 'volunteer_app_review' | 'profile_update' | 'matching' | 'user_opt_out';
   priority: 'no_status' | 'low' | 'medium' | 'high';
   status: 'pending' | 'in_progress' | 'completed';
   assigneeId: string | null;
@@ -26,7 +26,7 @@ export interface TaskListResponse {
 
 export interface UpdateTaskRequest {
   participantId?: string;
-  type?: 'intake_form_review' | 'volunteer_app_review' | 'profile_update' | 'matching';
+  type?: 'intake_form_review' | 'volunteer_app_review' | 'profile_update' | 'matching' | 'user_opt_out';
   priority?: 'no_status' | 'low' | 'medium' | 'high';
   status?: 'pending' | 'in_progress' | 'completed';
   assigneeId?: string | null;

--- a/frontend/src/pages/admin/tasks.tsx
+++ b/frontend/src/pages/admin/tasks.tsx
@@ -82,6 +82,7 @@ const mapAPITaskToFrontend = (
     volunteer_app_review: 'Ranking / Secondary App Review',
     profile_update: 'Profile Update',
     matching: 'Matching',
+    user_opt_out: 'User Opt Out',
   };
 
   // Map backend priority to frontend priority
@@ -98,6 +99,7 @@ const mapAPITaskToFrontend = (
     volunteer_app_review: 'secondary_app',
     profile_update: 'profile_updates',
     matching: 'matching_requests',
+    user_opt_out: 'user_opt_outs',
   };
 
   // Format dates from ISO to DD/MM/YY
@@ -132,12 +134,12 @@ const mapAPITaskToFrontend = (
     startDate: formatDate(apiTask.startDate),
     endDate: apiTask.endDate ? formatDate(apiTask.endDate) : formatDate(apiTask.startDate),
     priority: priorityMap[apiTask.priority] || 'Add status',
-    type: typeMap[apiTask.type] || 'Intake Form Review',
+    type: typeMap[apiTask.type] ?? 'Intake Form Review',
     assignee: assignee?.name,
     completed: apiTask.status === 'completed',
     userType,
-    category: categoryMap[apiTask.type] || 'intake_screening',
-    description: apiTask.description || `Task for ${typeMap[apiTask.type]}`,
+    category: categoryMap[apiTask.type] ?? 'intake_screening',
+    description: apiTask.description ?? `Task for ${typeMap[apiTask.type] ?? 'Intake Form Review'}`,
   };
 };
 

--- a/frontend/src/types/adminTypes.ts
+++ b/frontend/src/types/adminTypes.ts
@@ -2,14 +2,24 @@ export interface Task {
   id: string;
   name: string;
   participantId?: string;
-  type: 'Intake Form Review' | 'Ranking / Secondary App Review' | 'Matching' | 'Profile Update' | 'User Opt Out';
+  type:
+    | 'Intake Form Review'
+    | 'Ranking / Secondary App Review'
+    | 'Matching'
+    | 'Profile Update'
+    | 'User Opt Out';
   startDate: string;
   endDate: string;
   priority: 'High' | 'Medium' | 'Low' | 'Add status';
   assignee?: string;
   completed: boolean;
   userType: 'Participant' | 'Volunteer';
-  category: 'intake_screening' | 'secondary_app' | 'matching_requests' | 'profile_updates' | 'user_opt_outs';
+  category:
+    | 'intake_screening'
+    | 'secondary_app'
+    | 'matching_requests'
+    | 'profile_updates'
+    | 'user_opt_outs';
   description?: string;
 }
 

--- a/frontend/src/types/adminTypes.ts
+++ b/frontend/src/types/adminTypes.ts
@@ -2,14 +2,14 @@ export interface Task {
   id: string;
   name: string;
   participantId?: string;
-  type: 'Intake Form Review' | 'Ranking / Secondary App Review' | 'Matching' | 'Profile Update';
+  type: 'Intake Form Review' | 'Ranking / Secondary App Review' | 'Matching' | 'Profile Update' | 'User Opt Out';
   startDate: string;
   endDate: string;
   priority: 'High' | 'Medium' | 'Low' | 'Add status';
   assignee?: string;
   completed: boolean;
   userType: 'Participant' | 'Volunteer';
-  category: 'intake_screening' | 'secondary_app' | 'matching_requests' | 'profile_updates';
+  category: 'intake_screening' | 'secondary_app' | 'matching_requests' | 'profile_updates' | 'user_opt_outs';
   description?: string;
 }
 
@@ -32,6 +32,7 @@ export const categoryLabels: Record<Task['category'], string> = {
   secondary_app: 'Review secondary application / ranking forms',
   matching_requests: 'Participants requesting a match',
   profile_updates: 'User profile updates',
+  user_opt_outs: 'User opt outs',
 };
 
 export const taskCategories: TaskCategory[] = [
@@ -58,5 +59,11 @@ export const taskCategories: TaskCategory[] = [
     name: 'User profile updates',
     categoryKey: 'profile_updates',
     bgColor: '#EEEEEC',
+  },
+  {
+    id: '5',
+    name: 'User opt outs',
+    categoryKey: 'user_opt_outs',
+    bgColor: 'rgba(200, 200, 200, 0.4)',
   },
 ];

--- a/frontend/src/utils/taskHelpers.ts
+++ b/frontend/src/utils/taskHelpers.ts
@@ -8,6 +8,7 @@ export const getTypeColor = (type: string): { bg: string; color: string } => {
     'Ranking / Secondary App Review': { bg: COLORS.bgTealLight, color: COLORS.teal },
     Matching: { bg: COLORS.bgPinkLight, color: COLORS.red },
     'Profile Update': { bg: COLORS.bgGrayLight, color: COLORS.gray700 },
+    'User Opt Out': { bg: 'rgba(200, 200, 200, 0.4)', color: COLORS.gray700 },
   };
   return typeColors[type] || { bg: COLORS.bgGrayLight, color: COLORS.gray700 };
 };
@@ -28,6 +29,7 @@ export const getCategoryColor = (categoryKey: string): string => {
     secondary_app: COLORS.bgTealLight,
     matching_requests: COLORS.bgPinkLight,
     profile_updates: COLORS.bgGrayLight,
+    user_opt_outs: 'rgba(200, 200, 200, 0.4)',
   };
   return categoryColors[categoryKey] || COLORS.bgGrayLight;
 };

--- a/frontend/src/utils/taskLinkHelpers.ts
+++ b/frontend/src/utils/taskLinkHelpers.ts
@@ -20,6 +20,8 @@ export const getParticipantLink = (task: Task): string => {
     return `${baseUrl}?tab=profile`;
   } else if (task.type === 'Intake Form Review' || task.type === 'Ranking / Secondary App Review') {
     return `${baseUrl}?tab=forms`;
+  } else if (task.type === 'User Opt Out') {
+    return baseUrl;
   } else {
     // Default: profile tab
     return baseUrl;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/create-task-when-user-opts-out-to-inform-admins-2fa10f3fb1dc806b8743faaf5188a7d9)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* When user opts out create task


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Opt out check admin page


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
