### PR TITLE
Mobile styling: Add MobileHeader and MobileDrawer components

### DIFF
--- a/frontend/src/components/dashboard/EditProfileModal.tsx
+++ b/frontend/src/components/dashboard/EditProfileModal.tsx
@@ -770,7 +770,7 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({ isOpen, onClose }) 
         fontWeight={600}
         color="#1D3448"
         fontFamily="'Open Sans', sans-serif"
-        letterSpacing="-1.5%"
+        letterSpacing="-0.015em"
         mb={6}
         textAlign="center"
       >
@@ -871,7 +871,7 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({ isOpen, onClose }) 
           fontWeight={600}
           color="#1D3448"
           fontFamily="'Open Sans', sans-serif"
-          letterSpacing="-1.5%"
+          letterSpacing="-0.015em"
           mb="48px"
         >
           {t('editProfile')}

--- a/frontend/src/components/dashboard/EditProfileModal.tsx
+++ b/frontend/src/components/dashboard/EditProfileModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import TimeScheduler from '@/components/dashboard/TimeScheduler';
 import type { TimeSlot } from '@/components/dashboard/types';
-import { Box, Heading, Text, VStack, HStack, Button, Image } from '@chakra-ui/react';
+import { Box, Heading, Text, VStack, HStack, Button, Image, Tabs } from '@chakra-ui/react';
 import PersonalDetails from '@/components/dashboard/PersonalDetails';
 import BloodCancerExperience from '@/components/dashboard/BloodCancerExperience';
 import VolunteerAccountSettings from '@/components/volunteer/VolunteerAccountSettings';
@@ -16,6 +16,7 @@ import {
 } from '@/APIClients/userDataAPIClient';
 import { extractTimezoneAbbreviation, getTimezoneDisplayName } from '@/utils/timezoneUtils';
 import { useTranslations } from 'next-intl';
+import { useIsDesktop } from '@/hooks/useIsDesktop';
 import type { Locale } from '@/i18n/config';
 
 interface EditProfileModalProps {
@@ -31,6 +32,8 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({ isOpen, onClose }) 
   const [loading, setLoading] = useState(true);
   const [savingAvailability, setSavingAvailability] = useState(false);
   const [hasBloodCancer, setHasBloodCancer] = useState(false);
+  const isDesktop = useIsDesktop();
+  const [selectedMobileDay, setSelectedMobileDay] = useState<string>('Sunday');
 
   // Personal details state for profile
   const [personalDetails, setPersonalDetails] = useState<{
@@ -435,7 +438,7 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({ isOpen, onClose }) 
         <Box
           minH="100vh"
           bg="white"
-          p={12}
+          p={{ base: 4, lg: 12 }}
           display="flex"
           justifyContent="center"
           alignItems="center"
@@ -448,6 +451,442 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({ isOpen, onClose }) 
     );
   }
 
+  // Mobile day abbreviations for availability selector
+  const mobileDays = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
+  const dayFullNames: Record<string, string> = {
+    SUN: 'Sunday',
+    MON: 'Monday',
+    TUE: 'Tuesday',
+    WED: 'Wednesday',
+    THU: 'Thursday',
+    FRI: 'Friday',
+    SAT: 'Saturday',
+  };
+  const hours = Array.from({ length: 13 }, (_, i) => i + 8); // 8 AM to 8 PM
+
+  const formatMobileTime = (hour: number) => {
+    if (hour <= 11) {
+      return `${hour} AM`;
+    } else if (hour === 12) {
+      return `12 PM`;
+    } else {
+      return `${hour - 12} PM`;
+    }
+  };
+
+  const isTimeSlotSelectedForDay = (day: string, hour: number) => {
+    const timeStr = `${hour}:00 - ${hour + 1}:00`;
+    return profileTimeSlots.some((slot) => slot.day === day && slot.time === timeStr);
+  };
+
+  const handleMobileTimeSlotToggle = (day: string, hour: number) => {
+    if (!isEditingAvailability) return;
+    const timeStr = `${hour}:00 - ${hour + 1}:00`;
+    const existingSlotIndex = profileTimeSlots.findIndex(
+      (slot) => slot.day === day && slot.time === timeStr,
+    );
+
+    let newSlots: TimeSlot[];
+    if (existingSlotIndex >= 0) {
+      newSlots = profileTimeSlots.filter((_, index) => index !== existingSlotIndex);
+    } else {
+      newSlots = [...profileTimeSlots, { day, time: timeStr, selected: true }];
+    }
+
+    setProfileTimeSlots(newSlots);
+    if (handleTimeSlotsChange) {
+      handleTimeSlotsChange(newSlots);
+    }
+  };
+
+  // Render personal details content
+  const renderPersonalDetails = () => (
+    <PersonalDetails
+      personalDetails={personalDetails}
+      setPersonalDetails={setPersonalDetails}
+      lovedOneDetails={lovedOneDetails}
+      setLovedOneDetails={setLovedOneDetails}
+      onSave={handleSavePersonalDetail}
+      isVolunteer={true}
+    />
+  );
+
+  // Render blood cancer experience content
+  const renderHistory = () => (
+    <BloodCancerExperience
+      cancerExperience={cancerExperience}
+      setCancerExperience={setCancerExperience}
+      lovedOneCancerExperience={lovedOneCancerExperience}
+      setLovedOneCancerExperience={setLovedOneCancerExperience}
+      onEditTreatments={handleSaveTreatments}
+      onEditExperiences={handleSaveExperiences}
+      onEditLovedOneTreatments={handleSaveLovedOneTreatments}
+      onEditLovedOneExperiences={handleSaveLovedOneExperiences}
+      hasBloodCancer={hasBloodCancer}
+    />
+  );
+
+  // Render availability content for desktop
+  const renderAvailabilityDesktop = () => (
+    <Box bg="white" p={0} mt="116px" w="100%" pb={12}>
+      <HStack justify="space-between" align="center" mb={0}>
+        <Heading
+          w="519px"
+          h="40px"
+          fontSize="1.625rem"
+          fontWeight={600}
+          lineHeight="40px"
+          letterSpacing="0%"
+          color="#1D3448"
+          fontFamily="'Open Sans', sans-serif"
+          mb="8px"
+        >
+          {t('yourAvailabilityHeading')}
+        </Heading>
+        {!isEditingAvailability ? (
+          <ActionButton onClick={handleEditAvailability}>{t('edit')}</ActionButton>
+        ) : (
+          <HStack gap={3}>
+            <Button
+              bg="#B91C1C"
+              color="white"
+              px={4}
+              py={2}
+              borderRadius="6px"
+              fontFamily="'Open Sans', sans-serif"
+              fontWeight={600}
+              fontSize="0.875rem"
+              _hover={{ bg: '#991B1B' }}
+              _active={{ bg: '#7F1D1D' }}
+              onClick={handleClearAvailability}
+            >
+              {t('clearAvailability')}
+            </Button>
+            <Button
+              bg="#6B7280"
+              color="white"
+              px={4}
+              py={2}
+              borderRadius="6px"
+              fontFamily="'Open Sans', sans-serif"
+              fontWeight={600}
+              fontSize="0.875rem"
+              _hover={{ bg: '#4B5563' }}
+              _active={{ bg: '#374151' }}
+              onClick={handleCancelEdit}
+            >
+              {t('cancel')}
+            </Button>
+            <Button
+              bg="#056067"
+              color="white"
+              px={4}
+              py={2}
+              borderRadius="6px"
+              fontFamily="'Open Sans', sans-serif"
+              fontWeight={600}
+              fontSize="0.875rem"
+              _hover={{ bg: '#044d52' }}
+              _active={{ bg: '#033e42' }}
+              onClick={handleSaveAvailability}
+              disabled={savingAvailability}
+            >
+              {savingAvailability ? t('saving') : t('save')}
+            </Button>
+          </HStack>
+        )}
+      </HStack>
+
+      <Text
+        fontSize="1rem"
+        fontWeight={400}
+        lineHeight="100%"
+        letterSpacing="0%"
+        color="#495D6C"
+        mb={4}
+        mt={0}
+        fontFamily="'Open Sans', sans-serif"
+      >
+        {t('weRequire2Hours')}
+      </Text>
+
+      <Box h="900px" w="100%" mr={0}>
+        <TimeScheduler
+          showAvailability={true}
+          onTimeSlotsChange={handleTimeSlotsChange}
+          initialTimeSlots={profileTimeSlots}
+          readOnly={!isEditingAvailability}
+        />
+      </Box>
+    </Box>
+  );
+
+  // Render mobile availability with day selector and vertical time list
+  const renderAvailabilityMobile = () => (
+    <VStack align="stretch" gap={4}>
+      <Text fontSize="16px" fontWeight={600} color="#1D3448" fontFamily="'Open Sans', sans-serif">
+        {t('yourAvailabilityHeading')}
+      </Text>
+      <Text fontSize="14px" fontWeight={400} color="#495D6C" fontFamily="'Open Sans', sans-serif">
+        {t('weRequire2Hours')}
+      </Text>
+
+      {/* Day selector pills */}
+      <HStack gap={2} overflowX="auto" pb={2}>
+        {mobileDays.map((day) => (
+          <Box
+            key={day}
+            px={3}
+            py={2}
+            borderRadius="full"
+            bg={selectedMobileDay === dayFullNames[day] ? '#1D3448' : 'white'}
+            color={selectedMobileDay === dayFullNames[day] ? 'white' : '#1D3448'}
+            border="1px solid"
+            borderColor={selectedMobileDay === dayFullNames[day] ? '#1D3448' : '#E5E7EB'}
+            cursor="pointer"
+            onClick={() => setSelectedMobileDay(dayFullNames[day])}
+            fontFamily="'Open Sans', sans-serif"
+            fontSize="14px"
+            fontWeight={500}
+            flexShrink={0}
+          >
+            {day}
+          </Box>
+        ))}
+      </HStack>
+
+      {/* Vertical time slots list */}
+      <VStack align="stretch" gap={0}>
+        {hours.map((hour) => {
+          const isSelected = isTimeSlotSelectedForDay(selectedMobileDay, hour);
+          return (
+            <Box
+              key={hour}
+              py={3}
+              px={4}
+              borderBottom="1px solid"
+              borderColor="#E5E7EB"
+              display="flex"
+              alignItems="center"
+              justifyContent="space-between"
+              cursor={isEditingAvailability ? 'pointer' : 'default'}
+              onClick={() => handleMobileTimeSlotToggle(selectedMobileDay, hour)}
+              bg={isSelected ? 'rgba(255, 187, 138, 0.2)' : 'white'}
+            >
+              <Text
+                fontSize="14px"
+                fontWeight={400}
+                color="#1D3448"
+                fontFamily="'Open Sans', sans-serif"
+              >
+                {formatMobileTime(hour)}
+              </Text>
+              {isSelected && (
+                <Box
+                  bg="rgba(255, 187, 138, 0.5)"
+                  color="#1D3448"
+                  px={3}
+                  py={1}
+                  borderRadius="4px"
+                  fontSize="12px"
+                  fontWeight={500}
+                  fontFamily="'Open Sans', sans-serif"
+                >
+                  {formatMobileTime(hour)} - {formatMobileTime(hour + 1)}
+                </Box>
+              )}
+            </Box>
+          );
+        })}
+      </VStack>
+
+      {/* Action buttons */}
+      {!isEditingAvailability ? (
+        <Button
+          bg="#056067"
+          color="white"
+          w="100%"
+          py={6}
+          borderRadius="8px"
+          fontFamily="'Open Sans', sans-serif"
+          fontWeight={600}
+          fontSize="16px"
+          _hover={{ bg: '#044d52' }}
+          _active={{ bg: '#033e42' }}
+          onClick={handleEditAvailability}
+        >
+          {t('editAvailability')}
+        </Button>
+      ) : (
+        <HStack gap={3}>
+          <Button
+            flex={1}
+            bg="#B91C1C"
+            color="white"
+            py={6}
+            borderRadius="8px"
+            fontFamily="'Open Sans', sans-serif"
+            fontWeight={600}
+            fontSize="14px"
+            _hover={{ bg: '#991B1B' }}
+            _active={{ bg: '#7F1D1D' }}
+            onClick={handleClearAvailability}
+          >
+            {t('clearAvailability')}
+          </Button>
+          <Button
+            flex={1}
+            bg="#056067"
+            color="white"
+            py={6}
+            borderRadius="8px"
+            fontFamily="'Open Sans', sans-serif"
+            fontWeight={600}
+            fontSize="14px"
+            _hover={{ bg: '#044d52' }}
+            _active={{ bg: '#033e42' }}
+            onClick={handleSaveAvailability}
+            disabled={savingAvailability}
+          >
+            {savingAvailability ? t('saving') : t('saveChanges')}
+          </Button>
+        </HStack>
+      )}
+    </VStack>
+  );
+
+  // Mobile layout with tabs
+  const renderMobileLayout = () => (
+    <Box minH="100vh" bg="white" px={4} py={6}>
+      <HStack gap={2} mb={4} cursor="pointer" onClick={onClose}>
+        <Image src="/icons/chevron-left.png" alt={t('back')} w="20px" h="20px" />
+        <Text fontSize="16px" color="#1D3448" fontFamily="'Open Sans', sans-serif" fontWeight={400}>
+          {t('back')}
+        </Text>
+      </HStack>
+
+      <Heading
+        fontSize="24px"
+        fontWeight={600}
+        color="#1D3448"
+        fontFamily="'Open Sans', sans-serif"
+        letterSpacing="-1.5%"
+        mb={6}
+        textAlign="center"
+      >
+        {t('editProfile')}
+      </Heading>
+
+      <Tabs.Root defaultValue="personal" variant="line">
+        <Tabs.List mb={6} borderBottomWidth="1px" borderColor="#E5E7EB" gap={0}>
+          <Tabs.Trigger
+            value="personal"
+            flex={1}
+            fontSize="14px"
+            fontWeight={400}
+            fontFamily="'Open Sans', sans-serif"
+            color="#6B7280"
+            pb={3}
+            _selected={{
+              color: '#1D3448',
+              fontWeight: 600,
+              borderBottomWidth: '2px',
+              borderColor: '#1D3448',
+            }}
+          >
+            {t('personalDetails')}
+          </Tabs.Trigger>
+          <Tabs.Trigger
+            value="history"
+            flex={1}
+            fontSize="14px"
+            fontWeight={400}
+            fontFamily="'Open Sans', sans-serif"
+            color="#6B7280"
+            pb={3}
+            _selected={{
+              color: '#1D3448',
+              fontWeight: 600,
+              borderBottomWidth: '2px',
+              borderColor: '#1D3448',
+            }}
+          >
+            {t('history')}
+          </Tabs.Trigger>
+          <Tabs.Trigger
+            value="availability"
+            flex={1}
+            fontSize="14px"
+            fontWeight={400}
+            fontFamily="'Open Sans', sans-serif"
+            color="#6B7280"
+            pb={3}
+            _selected={{
+              color: '#1D3448',
+              fontWeight: 600,
+              borderBottomWidth: '2px',
+              borderColor: '#1D3448',
+            }}
+          >
+            {t('availability')}
+          </Tabs.Trigger>
+        </Tabs.List>
+
+        <Tabs.Content value="personal">
+          <VStack gap={0} align="stretch">
+            {renderPersonalDetails()}
+            <VolunteerAccountSettings />
+          </VStack>
+        </Tabs.Content>
+
+        <Tabs.Content value="history">
+          <VStack gap={0} align="stretch">
+            {renderHistory()}
+          </VStack>
+        </Tabs.Content>
+
+        <Tabs.Content value="availability">{renderAvailabilityMobile()}</Tabs.Content>
+      </Tabs.Root>
+    </Box>
+  );
+
+  // Desktop layout (original)
+  const renderDesktopLayout = () => (
+    <Box minH="100vh" bg="white" p={12}>
+      <Box w="70%" mx="auto" overflowX="hidden">
+        <HStack gap={2} mb={4} cursor="pointer" onClick={onClose}>
+          <Image src="/icons/chevron-left.png" alt={t('back')} w="20px" h="20px" />
+          <Text
+            fontSize="16px"
+            color="#1D3448"
+            fontFamily="'Open Sans', sans-serif"
+            fontWeight={400}
+          >
+            {t('back')}
+          </Text>
+        </HStack>
+
+        <Heading
+          fontSize="36px"
+          fontWeight={600}
+          color="#1D3448"
+          fontFamily="'Open Sans', sans-serif"
+          letterSpacing="-1.5%"
+          mb="48px"
+        >
+          {t('editProfile')}
+        </Heading>
+
+        <VStack gap={0} align="stretch">
+          {renderPersonalDetails()}
+          {renderHistory()}
+          {renderAvailabilityDesktop()}
+          <VolunteerAccountSettings />
+        </VStack>
+      </Box>
+    </Box>
+  );
+
   return (
     <Box
       position="fixed"
@@ -459,146 +898,7 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({ isOpen, onClose }) 
       zIndex={9999}
       overflowY="auto"
     >
-      <Box minH="100vh" bg="white" p={12}>
-        <Box w="70%" mx="auto" overflowX="hidden">
-          <HStack gap={2} mb={4} cursor="pointer" onClick={onClose}>
-            <Image src="/icons/chevron-left.png" alt={t('back')} w="20px" h="20px" />
-            <Text
-              fontSize="16px"
-              color="#1D3448"
-              fontFamily="'Open Sans', sans-serif"
-              fontWeight={400}
-            >
-              {t('back')}
-            </Text>
-          </HStack>
-
-          <Heading
-            fontSize="36px"
-            fontWeight={600}
-            color="#1D3448"
-            fontFamily="'Open Sans', sans-serif"
-            letterSpacing="-1.5%"
-            mb="48px"
-          >
-            {t('editProfile')}
-          </Heading>
-
-          <VStack gap={0} align="stretch">
-            <PersonalDetails
-              personalDetails={personalDetails}
-              setPersonalDetails={setPersonalDetails}
-              lovedOneDetails={lovedOneDetails}
-              setLovedOneDetails={setLovedOneDetails}
-              onSave={handleSavePersonalDetail}
-              isVolunteer={true}
-            />
-            <BloodCancerExperience
-              cancerExperience={cancerExperience}
-              setCancerExperience={setCancerExperience}
-              lovedOneCancerExperience={lovedOneCancerExperience}
-              setLovedOneCancerExperience={setLovedOneCancerExperience}
-              onEditTreatments={handleSaveTreatments}
-              onEditExperiences={handleSaveExperiences}
-              onEditLovedOneTreatments={handleSaveLovedOneTreatments}
-              onEditLovedOneExperiences={handleSaveLovedOneExperiences}
-              hasBloodCancer={hasBloodCancer}
-            />
-            <Box bg="white" p={0} mt="116px" w="100%" pb={12}>
-              <HStack justify="space-between" align="center" mb={0}>
-                <Heading
-                  w="519px"
-                  h="40px"
-                  fontSize="1.625rem"
-                  fontWeight={600}
-                  lineHeight="40px"
-                  letterSpacing="0%"
-                  color="#1D3448"
-                  fontFamily="'Open Sans', sans-serif"
-                  mb="8px"
-                >
-                  {t('yourAvailabilityHeading')}
-                </Heading>
-                {!isEditingAvailability ? (
-                  <ActionButton onClick={handleEditAvailability}>{t('edit')}</ActionButton>
-                ) : (
-                  <HStack gap={3}>
-                    <Button
-                      bg="#B91C1C"
-                      color="white"
-                      px={4}
-                      py={2}
-                      borderRadius="6px"
-                      fontFamily="'Open Sans', sans-serif"
-                      fontWeight={600}
-                      fontSize="0.875rem"
-                      _hover={{ bg: '#991B1B' }}
-                      _active={{ bg: '#7F1D1D' }}
-                      onClick={handleClearAvailability}
-                    >
-                      {t('clearAvailability')}
-                    </Button>
-                    <Button
-                      bg="#6B7280"
-                      color="white"
-                      px={4}
-                      py={2}
-                      borderRadius="6px"
-                      fontFamily="'Open Sans', sans-serif"
-                      fontWeight={600}
-                      fontSize="0.875rem"
-                      _hover={{ bg: '#4B5563' }}
-                      _active={{ bg: '#374151' }}
-                      onClick={handleCancelEdit}
-                    >
-                      {t('cancel')}
-                    </Button>
-                    <Button
-                      bg="#056067"
-                      color="white"
-                      px={4}
-                      py={2}
-                      borderRadius="6px"
-                      fontFamily="'Open Sans', sans-serif"
-                      fontWeight={600}
-                      fontSize="0.875rem"
-                      _hover={{ bg: '#044d52' }}
-                      _active={{ bg: '#033e42' }}
-                      onClick={handleSaveAvailability}
-                      disabled={savingAvailability}
-                    >
-                      {savingAvailability ? t('saving') : t('save')}
-                    </Button>
-                  </HStack>
-                )}
-              </HStack>
-
-              <Text
-                fontSize="1rem"
-                fontWeight={400}
-                lineHeight="100%"
-                letterSpacing="0%"
-                color="#495D6C"
-                mb={4}
-                mt={0}
-                fontFamily="'Open Sans', sans-serif"
-              >
-                {t('weRequire2Hours')}
-              </Text>
-
-              <Box h="900px" w="100%" mr={0}>
-                <TimeScheduler
-                  showAvailability={true}
-                  onTimeSlotsChange={handleTimeSlotsChange}
-                  initialTimeSlots={profileTimeSlots}
-                  readOnly={!isEditingAvailability}
-                />
-              </Box>
-            </Box>
-            <VolunteerAccountSettings />
-          </VStack>
-        </Box>
-      </Box>
+      {isDesktop ? renderDesktopLayout() : renderMobileLayout()}
     </Box>
   );
 };

--- a/frontend/src/components/dashboard/ProfileCard.tsx
+++ b/frontend/src/components/dashboard/ProfileCard.tsx
@@ -4,6 +4,7 @@ import { Avatar } from '@/components/ui/avatar';
 import Badge from './Badge';
 import { COLORS } from '@/constants/form';
 import { useTranslations } from 'next-intl';
+import { useIsDesktop } from '@/hooks/useIsDesktop';
 
 interface ProfileCardProps {
   participant: {
@@ -31,6 +32,7 @@ const ProfileCard: React.FC<ProfileCardProps> = ({
   onViewContact,
 }) => {
   const t = useTranslations('dashboard');
+  const isDesktop = useIsDesktop();
   const formatTime = (date: Date) => {
     return date.toLocaleTimeString('en-US', {
       hour: 'numeric',
@@ -41,11 +43,11 @@ const ProfileCard: React.FC<ProfileCardProps> = ({
 
   if (showTimes && time) {
     return (
-      <HStack gap="24px" align="start" w="100%">
+      <HStack gap={{ base: '12px', lg: '24px' }} align="start" w="100%">
         {/* Time with vertical line */}
-        <HStack gap="24px" align="start">
+        <HStack gap={{ base: '12px', lg: '24px' }} align="start">
           <Text
-            fontSize="1rem"
+            fontSize={{ base: '0.875rem', lg: '1rem' }}
             fontWeight={400}
             color="#6B7280"
             fontFamily="'Open Sans', sans-serif"
@@ -53,7 +55,7 @@ const ProfileCard: React.FC<ProfileCardProps> = ({
           >
             {formatTime(time)}
           </Text>
-          <Box w="4px" h="371px" bg="#5F989D" borderRadius="11px" />
+          <Box w="4px" minH={{ base: '200px', lg: '371px' }} bg="#5F989D" borderRadius="11px" />
         </HStack>
 
         {/* Card */}
@@ -61,6 +63,7 @@ const ProfileCard: React.FC<ProfileCardProps> = ({
           participant={participant}
           onScheduleCall={onScheduleCall}
           onViewContact={onViewContact}
+          isDesktop={isDesktop}
         />
       </HStack>
     );
@@ -71,6 +74,7 @@ const ProfileCard: React.FC<ProfileCardProps> = ({
       participant={participant}
       onScheduleCall={onScheduleCall}
       onViewContact={onViewContact}
+      isDesktop={isDesktop}
     />
   );
 };
@@ -79,7 +83,8 @@ const ProfileCardContent: React.FC<{
   participant: ProfileCardProps['participant'];
   onScheduleCall?: () => void;
   onViewContact?: () => void;
-}> = ({ participant, onScheduleCall, onViewContact }) => {
+  isDesktop: boolean;
+}> = ({ participant, onScheduleCall, onViewContact, isDesktop }) => {
   const t = useTranslations('dashboard');
   const tOptions = useTranslations('options');
 
@@ -94,54 +99,56 @@ const ProfileCardContent: React.FC<{
 
   return (
     <Box
-      w="675px"
-      h="371px"
+      w={{ base: '100%', lg: '675px' }}
+      minH={{ base: 'auto', lg: '371px' }}
       border="1px solid #D5D7DA"
       borderRadius="8px"
       bg="white"
       boxShadow="0 1px 2px 0 rgba(0, 0, 0, 0.05)"
-      py="24px"
-      px="28px"
+      py={{ base: '16px', lg: '24px' }}
+      px={{ base: '16px', lg: '28px' }}
+      pb={{ base: '16px', lg: '24px' }}
       position="relative"
     >
       <VStack align="start" gap={0}>
-        <HStack gap="32px" align="start">
+        <HStack gap={{ base: '12px', lg: '32px' }} align="start">
           {/* Avatar */}
           <Avatar
             name={participant.name}
-            size="xl"
+            size={isDesktop ? 'xl' : 'lg'}
             bg="#F4F4F4"
             color="#000000"
-            fontSize="36.52px"
+            fontSize={isDesktop ? '36.52px' : '24px'}
           />
 
           {/* Participant Info */}
-          <VStack align="start" gap={2}>
-            <HStack gap={2} align="center">
+          <VStack align="start" gap={2} flex={1}>
+            <HStack gap={2} align="center" wrap="wrap">
               <Text
-                fontSize="1.5rem"
+                fontSize={{ base: '1.125rem', lg: '1.5rem' }}
                 fontWeight={600}
                 color="#1D3448"
                 fontFamily="'Open Sans', sans-serif"
-                lineHeight="1.875rem"
+                lineHeight={{ base: '1.5rem', lg: '1.875rem' }}
                 letterSpacing="0%"
               >
                 {participant.name}
               </Text>
-              <Text
-                fontSize="1rem"
-                fontWeight={400}
-                color="#495D6C"
-                fontFamily="'Open Sans', sans-serif"
-                lineHeight="100%"
-                letterSpacing="0%"
-                mr="16px"
-              >
-                {participant.pronouns}
-              </Text>
+              {participant.pronouns && (
+                <Text
+                  fontSize={{ base: '0.875rem', lg: '1rem' }}
+                  fontWeight={400}
+                  color="#495D6C"
+                  fontFamily="'Open Sans', sans-serif"
+                  lineHeight="100%"
+                  letterSpacing="0%"
+                >
+                  {participant.pronouns}
+                </Text>
+              )}
             </HStack>
 
-            <HStack gap={2} align="center" wrap="wrap" mt="16px">
+            <HStack gap={2} align="center" wrap="wrap" mt={{ base: '8px', lg: '16px' }}>
               <Badge iconSrc="/icons/user-secondary.png">
                 {t('currentAge')} {participant.age}
               </Badge>
@@ -156,38 +163,40 @@ const ProfileCardContent: React.FC<{
         </HStack>
 
         {/* Treatment Information - Left aligned to the box */}
-        <Box mt={4}>
-          <Text
-            fontSize="1.125rem"
-            fontWeight={600}
-            color="#1D3448"
-            fontFamily="'Open Sans', sans-serif"
-            lineHeight="1.875rem"
-            letterSpacing="0%"
-            mb="16px"
-          >
-            {t('treatmentInformation')}
-          </Text>
-          <HStack gap={2} wrap="wrap">
-            {participant.treatments.map((treatment: string, index: number) => (
-              <Badge key={index} bgColor="#EEF4FF" textColor="#3538CD">
-                {translateOption('treatments', treatment)}
-              </Badge>
-            ))}
-          </HStack>
-        </Box>
-
-        {/* Experience Information */}
-        {participant.experiences && participant.experiences.length > 0 && (
+        {participant.treatments && participant.treatments.length > 0 && (
           <Box mt={4}>
             <Text
-              fontSize="1.125rem"
+              fontSize={{ base: '1rem', lg: '1.125rem' }}
               fontWeight={600}
               color="#1D3448"
               fontFamily="'Open Sans', sans-serif"
               lineHeight="1.875rem"
               letterSpacing="0%"
-              mb="16px"
+              mb={{ base: '8px', lg: '16px' }}
+            >
+              {t('treatmentInformation')}
+            </Text>
+            <HStack gap={2} wrap="wrap">
+              {participant.treatments.map((treatment: string, index: number) => (
+                <Badge key={index} bgColor="#EEF4FF" textColor="#3538CD">
+                  {translateOption('treatments', treatment)}
+                </Badge>
+              ))}
+            </HStack>
+          </Box>
+        )}
+
+        {/* Experience Information */}
+        {participant.experiences && participant.experiences.length > 0 && (
+          <Box mt={4}>
+            <Text
+              fontSize={{ base: '1rem', lg: '1.125rem' }}
+              fontWeight={600}
+              color="#1D3448"
+              fontFamily="'Open Sans', sans-serif"
+              lineHeight="1.875rem"
+              letterSpacing="0%"
+              mb={{ base: '8px', lg: '16px' }}
             >
               {t('experienceInformation')}
             </Text>
@@ -202,29 +211,33 @@ const ProfileCardContent: React.FC<{
         )}
       </VStack>
 
-      {/* Action Button - Positioned at bottom */}
-      <Button
-        position="absolute"
-        bottom="24px"
-        right="28px"
-        bg={COLORS.teal}
-        color="white"
-        fontWeight={600}
-        fontSize="0.875rem"
-        fontFamily="'Open Sans', sans-serif"
-        px={6}
-        py={3}
-        borderRadius="6px"
-        _hover={{
-          bg: '#056067',
-        }}
-        _active={{
-          bg: '#044953',
-        }}
-        onClick={onViewContact || onScheduleCall}
-      >
-        {onViewContact ? t('viewContactDetails') : t('scheduleCall')}
-      </Button>
+      {/* Action Button */}
+      {(onViewContact || onScheduleCall) && (
+        <Button
+          position={isDesktop ? 'absolute' : 'relative'}
+          bottom={isDesktop ? '24px' : undefined}
+          right={isDesktop ? '28px' : undefined}
+          w={{ base: '100%', lg: 'auto' }}
+          mt={{ base: 4, lg: 0 }}
+          bg={COLORS.teal}
+          color="white"
+          fontWeight={600}
+          fontSize="0.875rem"
+          fontFamily="'Open Sans', sans-serif"
+          px={6}
+          py={3}
+          borderRadius="6px"
+          _hover={{
+            bg: '#056067',
+          }}
+          _active={{
+            bg: '#044953',
+          }}
+          onClick={onViewContact || onScheduleCall}
+        >
+          {onViewContact ? t('viewContactDetails') : t('scheduleCall')}
+        </Button>
+      )}
     </Box>
   );
 };

--- a/frontend/src/components/dashboard/VolunteerDashboardLayout.tsx
+++ b/frontend/src/components/dashboard/VolunteerDashboardLayout.tsx
@@ -6,29 +6,23 @@ import { useTranslations } from 'next-intl';
 
 import { Avatar } from '@/components/ui/avatar';
 import { getCurrentUser, logout } from '@/APIClients/authAPIClient';
+import { useIsDesktop } from '@/hooks/useIsDesktop';
+import { MobileHeader } from '@/components/layout/MobileHeader';
+import { MobileDrawer } from '@/components/layout/MobileDrawer';
+import type { NavItem } from '@/components/layout/MobileDrawer';
 import EditProfileModal from './EditProfileModal';
 
 interface VolunteerDashboardLayoutProps {
   children: React.ReactNode;
 }
 
-export const VolunteerDashboardLayout: React.FC<VolunteerDashboardLayoutProps> = ({ children }) => {
+// Hook to get nav items for use in mobile drawer
+export function useVolunteerNavItems(): NavItem[] {
   const t = useTranslations('dashboard');
-  const [userName, setUserName] = useState('');
-  const [isEditProfileOpen, setIsEditProfileOpen] = useState(false);
-
-  useEffect(() => {
-    const user = getCurrentUser();
-    if (user) {
-      const fullName = `${user.firstName || ''} ${user.lastName || ''}`.trim();
-      setUserName(fullName || user.email);
-    }
-  }, []);
-
   const router = useRouter();
   const currentPath = router.asPath;
 
-  const navigationItems = [
+  return [
     {
       icon: '/icons/user-primary.png',
       label: t('matches'),
@@ -48,6 +42,24 @@ export const VolunteerDashboardLayout: React.FC<VolunteerDashboardLayoutProps> =
       isActive: currentPath === '/volunteer/dashboard/contact',
     },
   ];
+}
+
+export const VolunteerDashboardLayout: React.FC<VolunteerDashboardLayoutProps> = ({ children }) => {
+  const t = useTranslations('dashboard');
+  const router = useRouter();
+  const isDesktop = useIsDesktop();
+  const navigationItems = useVolunteerNavItems();
+  const [userName, setUserName] = useState('');
+  const [isEditProfileOpen, setIsEditProfileOpen] = useState(false);
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+
+  useEffect(() => {
+    const user = getCurrentUser();
+    if (user) {
+      const fullName = `${user.firstName || ''} ${user.lastName || ''}`.trim();
+      setUserName(fullName || user.email);
+    }
+  }, []);
 
   const handleNavigation = (path: string) => {
     router.push(path);
@@ -58,131 +70,156 @@ export const VolunteerDashboardLayout: React.FC<VolunteerDashboardLayoutProps> =
   };
 
   return (
-    <Box minH="100vh" bg="white" py={10}>
-      <Container maxW="container.xl">
-        <Flex
-          direction={{ base: 'column', lg: 'row' }}
-          align="flex-start"
-          gap={{ base: 8, lg: 12 }}
-        >
-          {/* Sidebar */}
-          <Box
-            w={{ base: '100%', lg: '279px' }}
-            flexShrink={0}
-            bg="white"
-            borderRadius="8px"
-            border="1px solid rgba(187, 194, 200, 0.5)"
-            p={2}
-            display="flex"
-            flexDirection="column"
-            overflow="visible"
+    <Box minH="100vh" bg="white">
+      {/* Mobile Header */}
+      {!isDesktop && (
+        <MobileHeader
+          userName={userName}
+          onMenuOpen={() => setIsMobileMenuOpen(true)}
+          onAvatarClick={() => setIsEditProfileOpen(true)}
+        />
+      )}
+
+      {/* Mobile Drawer */}
+      <MobileDrawer
+        isOpen={isMobileMenuOpen}
+        onClose={() => setIsMobileMenuOpen(false)}
+        userName={userName}
+        navItems={navigationItems}
+        onEditProfile={() => setIsEditProfileOpen(true)}
+      />
+
+      <Box py={{ base: 4, lg: 10 }}>
+        <Container maxW="container.xl" px={{ base: 4, lg: 8 }}>
+          <Flex
+            direction={{ base: 'column', lg: 'row' }}
+            align="flex-start"
+            gap={{ base: 6, lg: 12 }}
           >
-            {/* Logo */}
-            <Box
-              mb={0}
-              w="100%"
-              display="flex"
-              alignItems="center"
-              justifyContent="flex-start"
-              pl={4}
-            >
-              <Image
-                src="/llsc-logo.png"
-                alt="Leukemia & Lymphoma Society of Canada"
-                w="220px"
-                h="150px"
-                objectFit="contain"
-              />
-            </Box>
-
-            {/* Navigation */}
-            <VStack align="stretch" gap="8px" flex={1}>
-              {navigationItems.map((item) => (
-                <Button
-                  key={item.path}
-                  onClick={() => handleNavigation(item.path)}
-                  bg={item.isActive ? 'rgba(179, 206, 209, 0.3)' : 'transparent'}
-                  color={item.isActive ? '#1D3448' : '#6B7280'}
-                  fontWeight={item.isActive ? 600 : 400}
-                  fontSize="14px"
-                  fontFamily="'Open Sans', sans-serif"
-                  justifyContent="flex-start"
-                  h="50px"
-                  px="12px"
-                  py="8px"
-                  borderRadius="6px"
-                  _hover={{
-                    bg: item.isActive ? 'rgba(179, 206, 209, 0.3)' : '#F1F5F9',
-                  }}
-                  _active={{
-                    bg: item.isActive ? 'rgba(179, 206, 209, 0.3)' : '#E2E8F0',
-                  }}
-                >
-                  <HStack gap="8px" align="center">
-                    {item.icon && <Image src={item.icon} alt={item.label} w="14px" h="14px" />}
-                    <Text>{item.label}</Text>
-                  </HStack>
-                </Button>
-              ))}
-
-              {/* Sign Out */}
-              <Button
-                onClick={handleSignOut}
-                bg="transparent"
-                color="#6B7280"
-                fontWeight={400}
-                fontSize="14px"
-                fontFamily="'Open Sans', sans-serif"
-                justifyContent="flex-start"
-                h="50px"
-                px="12px"
-                py="8px"
-                borderRadius="6px"
-                _hover={{
-                  bg: '#F1F5F9',
-                }}
-                _active={{
-                  bg: '#E2E8F0',
-                }}
-              >
-                <HStack gap="8px" align="center">
-                  <Icon as={FiLogOut} w="14px" h="14px" />
-                  <Text>{t('signOut')}</Text>
-                </HStack>
-              </Button>
-            </VStack>
-          </Box>
-
-          {/* Main Content */}
-          <Box flex={1} w="full">
-            <Flex justify="space-between" align="flex-start" mb={6}>
-              <Box flex={1} />
-              {/* Profile Icon positioned at top right */}
+            {/* Sidebar - Desktop only */}
+            {isDesktop && (
               <Box
-                cursor="pointer"
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  setIsEditProfileOpen(true);
-                }}
-                _hover={{ opacity: 0.8 }}
-                transition="opacity 0.2s"
+                w="279px"
                 flexShrink={0}
-                ml={4}
+                bg="white"
+                borderRadius="8px"
+                border="1px solid rgba(187, 194, 200, 0.5)"
+                p={2}
+                display="flex"
+                flexDirection="column"
+                overflow="visible"
               >
-                <Avatar
-                  name={userName}
-                  size="lg"
-                  bg="rgba(179, 206, 209, 0.3)"
-                  color="#056067"
-                  fontWeight={500}
-                />
+                {/* Logo */}
+                <Box
+                  mb={0}
+                  w="100%"
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="flex-start"
+                  pl={4}
+                >
+                  <Image
+                    src="/llsc-logo.png"
+                    alt="Leukemia & Lymphoma Society of Canada"
+                    w="220px"
+                    h="150px"
+                    objectFit="contain"
+                  />
+                </Box>
+
+                {/* Navigation */}
+                <VStack align="stretch" gap="8px" flex={1}>
+                  {navigationItems.map((item) => (
+                    <Button
+                      key={item.path}
+                      onClick={() => handleNavigation(item.path)}
+                      bg={item.isActive ? 'rgba(179, 206, 209, 0.3)' : 'transparent'}
+                      color={item.isActive ? '#1D3448' : '#6B7280'}
+                      fontWeight={item.isActive ? 600 : 400}
+                      fontSize="14px"
+                      fontFamily="'Open Sans', sans-serif"
+                      justifyContent="flex-start"
+                      h="50px"
+                      px="12px"
+                      py="8px"
+                      borderRadius="6px"
+                      _hover={{
+                        bg: item.isActive ? 'rgba(179, 206, 209, 0.3)' : '#F1F5F9',
+                      }}
+                      _active={{
+                        bg: item.isActive ? 'rgba(179, 206, 209, 0.3)' : '#E2E8F0',
+                      }}
+                    >
+                      <HStack gap="8px" align="center">
+                        {item.icon && <Image src={item.icon} alt={item.label} w="14px" h="14px" />}
+                        <Text>{item.label}</Text>
+                      </HStack>
+                    </Button>
+                  ))}
+
+                  {/* Sign Out */}
+                  <Button
+                    onClick={handleSignOut}
+                    bg="transparent"
+                    color="#6B7280"
+                    fontWeight={400}
+                    fontSize="14px"
+                    fontFamily="'Open Sans', sans-serif"
+                    justifyContent="flex-start"
+                    h="50px"
+                    px="12px"
+                    py="8px"
+                    borderRadius="6px"
+                    _hover={{
+                      bg: '#F1F5F9',
+                    }}
+                    _active={{
+                      bg: '#E2E8F0',
+                    }}
+                  >
+                    <HStack gap="8px" align="center">
+                      <Icon as={FiLogOut} w="14px" h="14px" />
+                      <Text>{t('signOut')}</Text>
+                    </HStack>
+                  </Button>
+                </VStack>
               </Box>
-            </Flex>
-            {children}
-          </Box>
-        </Flex>
-      </Container>
+            )}
+
+            {/* Main Content */}
+            <Box flex={1} w="full">
+              {/* Desktop Avatar */}
+              {isDesktop && (
+                <Flex justify="space-between" align="flex-start" mb={6}>
+                  <Box flex={1} />
+                  {/* Profile Icon positioned at top right */}
+                  <Box
+                    cursor="pointer"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      setIsEditProfileOpen(true);
+                    }}
+                    _hover={{ opacity: 0.8 }}
+                    transition="opacity 0.2s"
+                    flexShrink={0}
+                    ml={4}
+                  >
+                    <Avatar
+                      name={userName}
+                      size="lg"
+                      bg="rgba(179, 206, 209, 0.3)"
+                      color="#056067"
+                      fontWeight={500}
+                    />
+                  </Box>
+                </Flex>
+              )}
+              {children}
+            </Box>
+          </Flex>
+        </Container>
+      </Box>
 
       {/* Edit Profile Modal */}
       <EditProfileModal isOpen={isEditProfileOpen} onClose={() => setIsEditProfileOpen(false)} />

--- a/frontend/src/components/dashboard/VolunteerDashboardLayout.tsx
+++ b/frontend/src/components/dashboard/VolunteerDashboardLayout.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Box, VStack, HStack, Text, Image, Button, Icon, Container, Flex } from '@chakra-ui/react';
+import { Box, VStack, HStack, Text, Image, Button, Container, Flex } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
 import { FiLogOut } from 'react-icons/fi';
 import { useTranslations } from 'next-intl';
@@ -178,7 +178,7 @@ export const VolunteerDashboardLayout: React.FC<VolunteerDashboardLayoutProps> =
                     }}
                   >
                     <HStack gap="8px" align="center">
-                      <Icon as={FiLogOut} w="14px" h="14px" />
+                      <FiLogOut size={14} />
                       <Text>{t('signOut')}</Text>
                     </HStack>
                   </Button>

--- a/frontend/src/components/layout/MobileDrawer.tsx
+++ b/frontend/src/components/layout/MobileDrawer.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import React from 'react';
+import { Box, VStack, HStack, Text, Image, Button, Icon, Separator } from '@chakra-ui/react';
+import { FiLogOut } from 'react-icons/fi';
+import { useRouter } from 'next/router';
+import { useTranslations } from 'next-intl';
+import {
+  DrawerRoot,
+  DrawerBackdrop,
+  DrawerContent,
+  DrawerCloseTrigger,
+  DrawerBody,
+} from '@/components/ui/drawer';
+import { Avatar } from '@/components/ui/avatar';
+import { logout } from '@/APIClients/authAPIClient';
+
+export interface NavItem {
+  label: string;
+  icon?: string;
+  path: string;
+  isActive: boolean;
+}
+
+interface MobileDrawerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  userName: string;
+  navItems: NavItem[];
+  onEditProfile?: () => void;
+}
+
+export const MobileDrawer: React.FC<MobileDrawerProps> = ({
+  isOpen,
+  onClose,
+  userName,
+  navItems,
+  onEditProfile,
+}) => {
+  const t = useTranslations('dashboard');
+  const router = useRouter();
+
+  const handleNavigation = (path: string) => {
+    router.push(path);
+    onClose();
+  };
+
+  const handleSignOut = async () => {
+    onClose();
+    await logout();
+  };
+
+  const handleProfileClick = () => {
+    if (onEditProfile) {
+      onEditProfile();
+      onClose();
+    }
+  };
+
+  return (
+    <DrawerRoot open={isOpen} onOpenChange={(e) => !e.open && onClose()} placement="start">
+      <DrawerBackdrop />
+      <DrawerContent maxW="280px" bg="white">
+        <DrawerCloseTrigger />
+        <DrawerBody p={0}>
+          <VStack align="stretch" h="100%" gap={0}>
+            {/* User Profile Section */}
+            <Box
+              px={4}
+              py={6}
+              cursor={onEditProfile ? 'pointer' : 'default'}
+              onClick={handleProfileClick}
+              _hover={onEditProfile ? { bg: 'gray.50' } : undefined}
+              transition="background 0.2s"
+            >
+              <HStack gap={3}>
+                <Avatar
+                  name={userName}
+                  size="lg"
+                  bg="rgba(179, 206, 209, 0.3)"
+                  color="#056067"
+                  fontWeight={500}
+                />
+                <Text
+                  fontSize="16px"
+                  fontWeight={600}
+                  color="#1D3448"
+                  fontFamily="'Open Sans', sans-serif"
+                >
+                  {userName}
+                </Text>
+              </HStack>
+            </Box>
+
+            <Separator />
+
+            {/* Navigation Items */}
+            <VStack align="stretch" gap={1} px={2} py={4} flex={1}>
+              {navItems.map((item) => (
+                <Button
+                  key={item.path}
+                  onClick={() => handleNavigation(item.path)}
+                  bg={item.isActive ? 'rgba(179, 206, 209, 0.3)' : 'transparent'}
+                  color={item.isActive ? '#1D3448' : '#6B7280'}
+                  fontWeight={item.isActive ? 600 : 400}
+                  fontSize="14px"
+                  fontFamily="'Open Sans', sans-serif"
+                  justifyContent="flex-start"
+                  h="50px"
+                  px={3}
+                  py={2}
+                  borderRadius="6px"
+                  _hover={{
+                    bg: item.isActive ? 'rgba(179, 206, 209, 0.3)' : '#F1F5F9',
+                  }}
+                  _active={{
+                    bg: item.isActive ? 'rgba(179, 206, 209, 0.3)' : '#E2E8F0',
+                  }}
+                >
+                  <HStack gap={3} align="center">
+                    {item.icon && <Image src={item.icon} alt={item.label} w="18px" h="18px" />}
+                    <Text>{item.label}</Text>
+                  </HStack>
+                </Button>
+              ))}
+            </VStack>
+
+            {/* Sign Out Button - At Bottom */}
+            <Box px={2} pb={6}>
+              <Button
+                onClick={handleSignOut}
+                bg="transparent"
+                color="#6B7280"
+                fontWeight={400}
+                fontSize="14px"
+                fontFamily="'Open Sans', sans-serif"
+                justifyContent="flex-start"
+                h="50px"
+                px={3}
+                py={2}
+                borderRadius="6px"
+                w="100%"
+                _hover={{
+                  bg: '#F1F5F9',
+                }}
+                _active={{
+                  bg: '#E2E8F0',
+                }}
+              >
+                <HStack gap={3} align="center">
+                  <Icon as={FiLogOut} w="18px" h="18px" />
+                  <Text>{t('signOut')}</Text>
+                </HStack>
+              </Button>
+            </Box>
+          </VStack>
+        </DrawerBody>
+      </DrawerContent>
+    </DrawerRoot>
+  );
+};
+
+export default MobileDrawer;

--- a/frontend/src/components/layout/MobileDrawer.tsx
+++ b/frontend/src/components/layout/MobileDrawer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { Box, VStack, HStack, Text, Image, Button, Icon, Separator } from '@chakra-ui/react';
+import { Box, VStack, HStack, Text, Image, Button, Separator } from '@chakra-ui/react';
 import { FiLogOut } from 'react-icons/fi';
 import { useRouter } from 'next/router';
 import { useTranslations } from 'next-intl';
@@ -148,7 +148,7 @@ export const MobileDrawer: React.FC<MobileDrawerProps> = ({
                 }}
               >
                 <HStack gap={3} align="center">
-                  <Icon as={FiLogOut} w="18px" h="18px" />
+                  <FiLogOut size={18} />
                   <Text>{t('signOut')}</Text>
                 </HStack>
               </Button>

--- a/frontend/src/components/layout/MobileHeader.tsx
+++ b/frontend/src/components/layout/MobileHeader.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import React from 'react';
+import { Box, Flex, IconButton } from '@chakra-ui/react';
+import { FiMenu } from 'react-icons/fi';
+import { Avatar } from '@/components/ui/avatar';
+
+interface MobileHeaderProps {
+  userName: string;
+  onMenuOpen: () => void;
+  onAvatarClick?: () => void;
+}
+
+export const MobileHeader: React.FC<MobileHeaderProps> = ({
+  userName,
+  onMenuOpen,
+  onAvatarClick,
+}) => {
+  return (
+    <Flex
+      w="100%"
+      h="56px"
+      px={4}
+      align="center"
+      justify="space-between"
+      bg="white"
+      borderBottom="1px solid"
+      borderColor="gray.100"
+      position="sticky"
+      top={0}
+      zIndex={10}
+    >
+      {/* Hamburger Menu Button */}
+      <IconButton
+        aria-label="Open menu"
+        variant="ghost"
+        size="lg"
+        onClick={onMenuOpen}
+        color="#1D3448"
+        _hover={{ bg: 'gray.100' }}
+      >
+        <FiMenu size={24} />
+      </IconButton>
+
+      {/* User Avatar */}
+      <Box
+        cursor={onAvatarClick ? 'pointer' : 'default'}
+        onClick={onAvatarClick}
+        _hover={onAvatarClick ? { opacity: 0.8 } : undefined}
+        transition="opacity 0.2s"
+      >
+        <Avatar
+          name={userName}
+          size="md"
+          bg="rgba(179, 206, 209, 0.3)"
+          color="#056067"
+          fontWeight={500}
+        />
+      </Box>
+    </Flex>
+  );
+};
+
+export default MobileHeader;

--- a/frontend/src/components/participant/ConfirmedMatchCard.tsx
+++ b/frontend/src/components/participant/ConfirmedMatchCard.tsx
@@ -4,6 +4,7 @@ import { Match } from '@/types/matchTypes';
 import { formatDateRelative, formatDateShort, formatTime } from '@/utils/dateUtils';
 import { Avatar } from '@/components/ui/avatar';
 import Badge from '@/components/dashboard/Badge';
+import { useIsDesktop } from '@/hooks/useIsDesktop';
 
 interface ConfirmedMatchCardProps {
   match: Match;
@@ -18,6 +19,7 @@ export function ConfirmedMatchCard({
 }: ConfirmedMatchCardProps) {
   const t = useTranslations('dashboard');
   const locale = useLocale();
+  const isDesktop = useIsDesktop();
   const { volunteer, chosenTimeBlock } = match;
 
   if (!chosenTimeBlock) {
@@ -52,10 +54,20 @@ export function ConfirmedMatchCard({
     <VStack align="stretch" gap={4}>
       {/* Date Badge - Above the card */}
       <Box display="flex" alignItems="center" gap={2} alignSelf="flex-start">
-        <Text fontSize="20px" fontWeight="600" color="#056067" fontFamily="Open Sans">
+        <Text
+          fontSize={{ base: '16px', lg: '20px' }}
+          fontWeight="600"
+          color="#056067"
+          fontFamily="Open Sans"
+        >
           {dateShort}
         </Text>
-        <Text fontSize="18px" fontWeight="400" color="#056067" fontFamily="Open Sans">
+        <Text
+          fontSize={{ base: '14px', lg: '18px' }}
+          fontWeight="400"
+          color="#056067"
+          fontFamily="Open Sans"
+        >
           {dateLabel}
         </Text>
       </Box>
@@ -65,7 +77,7 @@ export function ConfirmedMatchCard({
         {/* Time - to the left of blue bar */}
         <Box display="flex" alignItems="flex-start" pt={2}>
           <Text
-            fontSize="18px"
+            fontSize={{ base: '14px', lg: '18px' }}
             fontWeight="400"
             color="#1F2937"
             fontFamily="Open Sans"
@@ -85,23 +97,54 @@ export function ConfirmedMatchCard({
           border="1px solid"
           borderColor="#D5D7DA"
           borderRadius="8px"
-          p={7}
+          p={{ base: 4, lg: 7 }}
           boxShadow="0 1px 2px 0 rgba(0, 0, 0, 0.05)"
         >
           <VStack align="stretch" gap={0}>
             {/* Volunteer Info */}
-            <HStack gap={8} align="flex-start" mb={4}>
-              {/* Avatar */}
-              <Avatar
-                name={`${volunteer.firstName} ${volunteer.lastName}`}
-                size="xl"
-                bg="#F4F4F4"
-                color="#000000"
-                fontSize="36.52px"
-              />
+            <HStack
+              gap={{ base: 3, lg: 8 }}
+              align="flex-start"
+              mb={4}
+              flexDirection={{ base: 'column', lg: 'row' }}
+            >
+              {/* Avatar + Name row on mobile */}
+              <HStack gap={3} align="center" w="100%">
+                <Avatar
+                  name={`${volunteer.firstName} ${volunteer.lastName}`}
+                  size={isDesktop ? 'xl' : 'lg'}
+                  bg="#F4F4F4"
+                  color="#000000"
+                  fontSize={isDesktop ? '36.52px' : '24px'}
+                />
+                {/* Name and pronouns on mobile - inline with avatar */}
+                {!isDesktop && (
+                  <VStack align="start" gap={0} flex={1}>
+                    <Text
+                      fontSize="1.125rem"
+                      fontWeight={600}
+                      color="#1D3448"
+                      fontFamily="'Open Sans', sans-serif"
+                      lineHeight="1.5rem"
+                    >
+                      {volunteer.firstName} {volunteer.lastName}
+                    </Text>
+                    {pronounsText && (
+                      <Text
+                        fontSize="0.875rem"
+                        fontWeight={400}
+                        color="#495D6C"
+                        fontFamily="'Open Sans', sans-serif"
+                      >
+                        {pronounsText}
+                      </Text>
+                    )}
+                  </VStack>
+                )}
+              </HStack>
 
-              {/* Name, pronouns, and info badges */}
-              <VStack align="start" gap={2} flex={1}>
+              {/* Name, pronouns, and info badges - desktop layout */}
+              <VStack align="start" gap={2} flex={1} display={{ base: 'none', lg: 'flex' }}>
                 {/* Name and pronouns */}
                 <HStack gap={2} align="center">
                   <Text
@@ -157,21 +200,52 @@ export function ConfirmedMatchCard({
               </VStack>
             </HStack>
 
+            {/* Info badges - mobile only, below avatar/name row */}
+            {!isDesktop && (
+              <HStack gap={2} align="center" wrap="wrap" mb={4}>
+                {typeof volunteer.age === 'number' && (
+                  <Badge
+                    iconSrc="/icons/user-secondary.png"
+                    bgColor="rgba(179, 206, 209, 0.3)"
+                    textColor="#056067"
+                  >
+                    {t('currentAge')} {volunteer.age}
+                  </Badge>
+                )}
+                <Badge
+                  iconSrc="/icons/clock-secondary.png"
+                  bgColor="rgba(179, 206, 209, 0.3)"
+                  textColor="#056067"
+                >
+                  {t('timeZone')} {volunteerTimezone}
+                </Badge>
+                {volunteer.diagnosis && (
+                  <Badge
+                    iconSrc="/icons/activity-secondary.png"
+                    bgColor="rgba(179, 206, 209, 0.3)"
+                    textColor="#056067"
+                  >
+                    {volunteer.diagnosis}
+                  </Badge>
+                )}
+              </HStack>
+            )}
+
             {/* Overview Section */}
             {volunteer.overview && (
               <Box mt={4}>
                 <Text
-                  fontSize="1.125rem"
+                  fontSize={{ base: '1rem', lg: '1.125rem' }}
                   fontWeight={600}
                   color="#1D3448"
                   fontFamily="'Open Sans', sans-serif"
                   lineHeight="1.875rem"
-                  mb={4}
+                  mb={{ base: 2, lg: 4 }}
                 >
                   {t('overview')}
                 </Text>
                 <Text
-                  fontSize="1rem"
+                  fontSize={{ base: '0.875rem', lg: '1rem' }}
                   fontWeight={400}
                   color="#495D6C"
                   fontFamily="'Open Sans', sans-serif"
@@ -186,12 +260,12 @@ export function ConfirmedMatchCard({
             {volunteer.treatments && volunteer.treatments.length > 0 && (
               <Box mt={4}>
                 <Text
-                  fontSize="1.125rem"
+                  fontSize={{ base: '1rem', lg: '1.125rem' }}
                   fontWeight={600}
                   color="#1D3448"
                   fontFamily="'Open Sans', sans-serif"
                   lineHeight="1.875rem"
-                  mb={4}
+                  mb={{ base: 2, lg: 4 }}
                 >
                   {t('treatmentInformation')}
                 </Text>
@@ -209,12 +283,12 @@ export function ConfirmedMatchCard({
             {volunteer.experiences && volunteer.experiences.length > 0 && (
               <Box mt={4}>
                 <Text
-                  fontSize="1.125rem"
+                  fontSize={{ base: '1rem', lg: '1.125rem' }}
                   fontWeight={600}
                   color="#1D3448"
                   fontFamily="'Open Sans', sans-serif"
                   lineHeight="1.875rem"
-                  mb={4}
+                  mb={{ base: 2, lg: 4 }}
                 >
                   {t('experienceInformation')}
                 </Text>
@@ -229,7 +303,12 @@ export function ConfirmedMatchCard({
             )}
 
             {/* Action Buttons */}
-            <Flex justify="flex-end" gap={3} mt={6}>
+            <Flex
+              justify={{ base: 'stretch', lg: 'flex-end' }}
+              direction={{ base: 'column', lg: 'row' }}
+              gap={3}
+              mt={6}
+            >
               {onCancelCall && (
                 <Button
                   bg="#DC2626"
@@ -240,6 +319,7 @@ export function ConfirmedMatchCard({
                   fontWeight={600}
                   fontSize="md"
                   fontFamily="'Open Sans', sans-serif"
+                  w={{ base: '100%', lg: 'auto' }}
                   _hover={{ bg: '#B91C1C' }}
                   _active={{ bg: '#991B1B' }}
                   onClick={() => onCancelCall(match.id)}
@@ -257,6 +337,7 @@ export function ConfirmedMatchCard({
                   fontWeight={600}
                   fontSize="md"
                   fontFamily="'Open Sans', sans-serif"
+                  w={{ base: '100%', lg: 'auto' }}
                   _hover={{ bg: '#044d52' }}
                   _active={{ bg: '#033a3e' }}
                   onClick={() => onViewContactDetails(match.id)}

--- a/frontend/src/components/participant/ConfirmedMatchCard.tsx
+++ b/frontend/src/components/participant/ConfirmedMatchCard.tsx
@@ -18,9 +18,19 @@ export function ConfirmedMatchCard({
   onViewContactDetails,
 }: ConfirmedMatchCardProps) {
   const t = useTranslations('dashboard');
+  const tOptions = useTranslations('options');
   const locale = useLocale();
   const isDesktop = useIsDesktop();
   const { volunteer, chosenTimeBlock } = match;
+
+  // Helper to translate medical terms with fallback to original value
+  const translateOption = (category: 'treatments' | 'experiences' | 'diagnoses', value: string) => {
+    try {
+      return tOptions(`${category}.${value}`);
+    } catch {
+      return value;
+    }
+  };
 
   if (!chosenTimeBlock) {
     return null;
@@ -272,7 +282,7 @@ export function ConfirmedMatchCard({
                 <HStack gap={2} wrap="wrap">
                   {volunteer.treatments.map((treatment: string, index: number) => (
                     <Badge key={index} bgColor="#EEF4FF" textColor="#3538CD">
-                      {treatment}
+                      {translateOption('treatments', treatment)}
                     </Badge>
                   ))}
                 </HStack>
@@ -295,7 +305,7 @@ export function ConfirmedMatchCard({
                 <HStack gap={2} wrap="wrap">
                   {volunteer.experiences.map((experience: string, index: number) => (
                     <Badge key={index} bgColor="#FDF2FA" textColor="#C11574">
-                      {experience}
+                      {translateOption('experiences', experience)}
                     </Badge>
                   ))}
                 </HStack>

--- a/frontend/src/components/participant/DashboardSidebar.tsx
+++ b/frontend/src/components/participant/DashboardSidebar.tsx
@@ -3,13 +3,16 @@ import { useRouter } from 'next/router';
 import { FiLogOut } from 'react-icons/fi';
 import { useTranslations } from 'next-intl';
 import { logout } from '@/APIClients/authAPIClient';
+import { useIsDesktop } from '@/hooks/useIsDesktop';
+import type { NavItem } from '@/components/layout/MobileDrawer';
 
-export function DashboardSidebar() {
+// Hook to get nav items for use in mobile drawer
+export function useParticipantNavItems(): NavItem[] {
   const t = useTranslations('dashboard');
   const router = useRouter();
   const currentPath = router.asPath;
 
-  const navItems = [
+  return [
     {
       label: t('matches'),
       icon: '/icons/user-primary.png',
@@ -23,6 +26,13 @@ export function DashboardSidebar() {
       isActive: currentPath === '/participant/dashboard/contact',
     },
   ];
+}
+
+export function DashboardSidebar() {
+  const t = useTranslations('dashboard');
+  const router = useRouter();
+  const isDesktop = useIsDesktop();
+  const navItems = useParticipantNavItems();
 
   const handleNavigation = (path: string) => {
     router.push(path);
@@ -32,9 +42,14 @@ export function DashboardSidebar() {
     await logout();
   };
 
+  // Don't render sidebar on mobile - mobile uses MobileHeader + MobileDrawer
+  if (!isDesktop) {
+    return null;
+  }
+
   return (
     <Box
-      w={{ base: '100%', lg: '279px' }}
+      w="279px"
       flexShrink={0}
       bg="white"
       borderRadius="8px"

--- a/frontend/src/components/participant/DashboardSidebar.tsx
+++ b/frontend/src/components/participant/DashboardSidebar.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, HStack, Image, Text, VStack, Icon } from '@chakra-ui/react';
+import { Box, Button, HStack, Image, Text, VStack } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
 import { FiLogOut } from 'react-icons/fi';
 import { useTranslations } from 'next-intl';
@@ -121,7 +121,7 @@ export function DashboardSidebar() {
           }}
         >
           <HStack gap="8px" align="center">
-            <Icon as={FiLogOut} w="14px" h="14px" />
+            <FiLogOut size={14} />
             <Text>{t('signOut')}</Text>
           </HStack>
         </Button>

--- a/frontend/src/components/participant/ParticipantEditProfileModal.tsx
+++ b/frontend/src/components/participant/ParticipantEditProfileModal.tsx
@@ -269,7 +269,7 @@ const ParticipantEditProfileModal: React.FC<ParticipantEditProfileModalProps> = 
         <Box
           minH="100vh"
           bg="white"
-          p={12}
+          p={{ base: 4, lg: 12 }}
           display="flex"
           justifyContent="center"
           alignItems="center"
@@ -349,7 +349,7 @@ const ParticipantEditProfileModal: React.FC<ParticipantEditProfileModalProps> = 
         fontWeight={600}
         color="#1D3448"
         fontFamily="'Open Sans', sans-serif"
-        letterSpacing="-1.5%"
+        letterSpacing="-0.015em"
         mb={6}
         textAlign="center"
       >
@@ -431,7 +431,7 @@ const ParticipantEditProfileModal: React.FC<ParticipantEditProfileModalProps> = 
           fontWeight={600}
           color="#1D3448"
           fontFamily="'Open Sans', sans-serif"
-          letterSpacing="-1.5%"
+          letterSpacing="-0.015em"
           mb="48px"
         >
           {t('editProfile')}

--- a/frontend/src/components/participant/ParticipantEditProfileModal.tsx
+++ b/frontend/src/components/participant/ParticipantEditProfileModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Box, Heading, Text, VStack, HStack, Image } from '@chakra-ui/react';
+import { Box, Heading, Text, VStack, HStack, Image, Tabs } from '@chakra-ui/react';
 import PersonalDetails from '@/components/dashboard/PersonalDetails';
 import BloodCancerExperience from '@/components/dashboard/BloodCancerExperience';
 import AccountSettings from '@/components/participant/AccountSettings';
@@ -8,6 +8,7 @@ import { useLanguage } from '@/contexts/LanguageContext';
 import { getUserData, updateUserData } from '@/APIClients/userDataAPIClient';
 import { Language } from '@/types/authTypes';
 import { useTranslations } from 'next-intl';
+import { useIsDesktop } from '@/hooks/useIsDesktop';
 import type { Locale } from '@/i18n/config';
 
 interface ParticipantEditProfileModalProps {
@@ -23,6 +24,7 @@ const ParticipantEditProfileModal: React.FC<ParticipantEditProfileModalProps> = 
   const { user, loading: authLoading } = useAuth();
   const { locale, setLocale } = useLanguage();
   const [loading, setLoading] = useState(true);
+  const isDesktop = useIsDesktop();
 
   // Personal details state for profile
   const [personalDetails, setPersonalDetails] = useState({
@@ -280,6 +282,170 @@ const ParticipantEditProfileModal: React.FC<ParticipantEditProfileModalProps> = 
     );
   }
 
+  // Render personal details content
+  const renderPersonalDetails = () => (
+    <PersonalDetails
+      personalDetails={{
+        ...personalDetails,
+        preferredLanguage: personalDetails.preferredLanguage === Language.FRENCH ? 'fr' : 'en',
+      }}
+      setPersonalDetails={(updater) => {
+        if (typeof updater === 'function') {
+          setPersonalDetails((prev) => {
+            const updated = updater({
+              ...prev,
+              preferredLanguage: prev.preferredLanguage === Language.FRENCH ? 'fr' : 'en',
+            });
+            return {
+              ...updated,
+              preferredLanguage: (updated.preferredLanguage === 'fr'
+                ? Language.FRENCH
+                : Language.ENGLISH) as Language,
+            };
+          });
+        } else {
+          setPersonalDetails({
+            ...updater,
+            preferredLanguage: (updater.preferredLanguage === 'fr'
+              ? Language.FRENCH
+              : Language.ENGLISH) as Language,
+          });
+        }
+      }}
+      lovedOneDetails={lovedOneDetails}
+      setLovedOneDetails={setLovedOneDetails}
+      onSave={handleSavePersonalDetail}
+      isVolunteer={false}
+    />
+  );
+
+  // Render blood cancer experience content
+  const renderHistory = () => (
+    <BloodCancerExperience
+      cancerExperience={cancerExperience}
+      setCancerExperience={setCancerExperience}
+      lovedOneCancerExperience={lovedOneCancerExperience}
+      setLovedOneCancerExperience={setLovedOneCancerExperience}
+      onEditTreatments={handleSaveTreatments}
+      onEditExperiences={handleSaveExperiences}
+      onEditLovedOneTreatments={handleSaveLovedOneTreatments}
+      onEditLovedOneExperiences={handleSaveLovedOneExperiences}
+      hasBloodCancer={hasBloodCancer}
+    />
+  );
+
+  // Mobile layout with tabs
+  const renderMobileLayout = () => (
+    <Box minH="100vh" bg="white" px={4} py={6}>
+      <HStack gap={2} mb={4} cursor="pointer" onClick={onClose}>
+        <Image src="/icons/chevron-left.png" alt={t('back')} w="20px" h="20px" />
+        <Text fontSize="16px" color="#1D3448" fontFamily="'Open Sans', sans-serif" fontWeight={400}>
+          {t('back')}
+        </Text>
+      </HStack>
+
+      <Heading
+        fontSize="24px"
+        fontWeight={600}
+        color="#1D3448"
+        fontFamily="'Open Sans', sans-serif"
+        letterSpacing="-1.5%"
+        mb={6}
+        textAlign="center"
+      >
+        {t('editProfile')}
+      </Heading>
+
+      <Tabs.Root defaultValue="personal" variant="line">
+        <Tabs.List mb={6} borderBottomWidth="1px" borderColor="#E5E7EB" gap={0}>
+          <Tabs.Trigger
+            value="personal"
+            flex={1}
+            fontSize="14px"
+            fontWeight={400}
+            fontFamily="'Open Sans', sans-serif"
+            color="#6B7280"
+            pb={3}
+            _selected={{
+              color: '#1D3448',
+              fontWeight: 600,
+              borderBottomWidth: '2px',
+              borderColor: '#1D3448',
+            }}
+          >
+            {t('personalDetails')}
+          </Tabs.Trigger>
+          <Tabs.Trigger
+            value="history"
+            flex={1}
+            fontSize="14px"
+            fontWeight={400}
+            fontFamily="'Open Sans', sans-serif"
+            color="#6B7280"
+            pb={3}
+            _selected={{
+              color: '#1D3448',
+              fontWeight: 600,
+              borderBottomWidth: '2px',
+              borderColor: '#1D3448',
+            }}
+          >
+            {t('history')}
+          </Tabs.Trigger>
+        </Tabs.List>
+
+        <Tabs.Content value="personal">
+          <VStack gap={0} align="stretch">
+            {renderPersonalDetails()}
+            <AccountSettings />
+          </VStack>
+        </Tabs.Content>
+
+        <Tabs.Content value="history">
+          <VStack gap={0} align="stretch">
+            {renderHistory()}
+          </VStack>
+        </Tabs.Content>
+      </Tabs.Root>
+    </Box>
+  );
+
+  // Desktop layout (original)
+  const renderDesktopLayout = () => (
+    <Box minH="100vh" bg="white" p={12}>
+      <Box w="70%" mx="auto" overflowX="hidden">
+        <HStack gap={2} mb={4} cursor="pointer" onClick={onClose}>
+          <Image src="/icons/chevron-left.png" alt={t('back')} w="20px" h="20px" />
+          <Text
+            fontSize="16px"
+            color="#1D3448"
+            fontFamily="'Open Sans', sans-serif"
+            fontWeight={400}
+          >
+            {t('back')}
+          </Text>
+        </HStack>
+
+        <Heading
+          fontSize="36px"
+          fontWeight={600}
+          color="#1D3448"
+          fontFamily="'Open Sans', sans-serif"
+          letterSpacing="-1.5%"
+          mb="48px"
+        >
+          {t('editProfile')}
+        </Heading>
+
+        <VStack gap={0} align="stretch">
+          {renderPersonalDetails()}
+          {renderHistory()}
+          <AccountSettings />
+        </VStack>
+      </Box>
+    </Box>
+  );
+
   return (
     <Box
       position="fixed"
@@ -291,81 +457,7 @@ const ParticipantEditProfileModal: React.FC<ParticipantEditProfileModalProps> = 
       zIndex={9999}
       overflowY="auto"
     >
-      <Box minH="100vh" bg="white" p={12}>
-        <Box w="70%" mx="auto" overflowX="hidden">
-          <HStack gap={2} mb={4} cursor="pointer" onClick={onClose}>
-            <Image src="/icons/chevron-left.png" alt={t('back')} w="20px" h="20px" />
-            <Text
-              fontSize="16px"
-              color="#1D3448"
-              fontFamily="'Open Sans', sans-serif"
-              fontWeight={400}
-            >
-              {t('back')}
-            </Text>
-          </HStack>
-
-          <Heading
-            fontSize="36px"
-            fontWeight={600}
-            color="#1D3448"
-            fontFamily="'Open Sans', sans-serif"
-            letterSpacing="-1.5%"
-            mb="48px"
-          >
-            {t('editProfile')}
-          </Heading>
-
-          <VStack gap={0} align="stretch">
-            <PersonalDetails
-              personalDetails={{
-                ...personalDetails,
-                preferredLanguage:
-                  personalDetails.preferredLanguage === Language.FRENCH ? 'fr' : 'en',
-              }}
-              setPersonalDetails={(updater) => {
-                if (typeof updater === 'function') {
-                  setPersonalDetails((prev) => {
-                    const updated = updater({
-                      ...prev,
-                      preferredLanguage: prev.preferredLanguage === Language.FRENCH ? 'fr' : 'en',
-                    });
-                    return {
-                      ...updated,
-                      preferredLanguage: (updated.preferredLanguage === 'fr'
-                        ? Language.FRENCH
-                        : Language.ENGLISH) as Language,
-                    };
-                  });
-                } else {
-                  setPersonalDetails({
-                    ...updater,
-                    preferredLanguage: (updater.preferredLanguage === 'fr'
-                      ? Language.FRENCH
-                      : Language.ENGLISH) as Language,
-                  });
-                }
-              }}
-              lovedOneDetails={lovedOneDetails}
-              setLovedOneDetails={setLovedOneDetails}
-              onSave={handleSavePersonalDetail}
-              isVolunteer={false}
-            />
-            <BloodCancerExperience
-              cancerExperience={cancerExperience}
-              setCancerExperience={setCancerExperience}
-              lovedOneCancerExperience={lovedOneCancerExperience}
-              setLovedOneCancerExperience={setLovedOneCancerExperience}
-              onEditTreatments={handleSaveTreatments}
-              onEditExperiences={handleSaveExperiences}
-              onEditLovedOneTreatments={handleSaveLovedOneTreatments}
-              onEditLovedOneExperiences={handleSaveLovedOneExperiences}
-              hasBloodCancer={hasBloodCancer}
-            />
-            <AccountSettings />
-          </VStack>
-        </Box>
-      </Box>
+      {isDesktop ? renderDesktopLayout() : renderMobileLayout()}
     </Box>
   );
 };

--- a/frontend/src/components/participant/ViewContactDetailsModal.tsx
+++ b/frontend/src/components/participant/ViewContactDetailsModal.tsx
@@ -46,7 +46,7 @@ export function ViewContactDetailsModal({ isOpen, match, onClose }: ViewContactD
         w="90%"
         boxShadow="0px 8px 8px -4px rgba(10, 13, 18, 0.03), 0px 20px 24px -4px rgba(10, 13, 18, 0.08)"
       >
-        <Flex gap={6} align="flex-start">
+        <Flex gap={{ base: 4, lg: 6 }} align="flex-start" direction={{ base: 'column', lg: 'row' }}>
           {/* Phone Icon */}
           <Box
             w="48px"
@@ -59,29 +59,32 @@ export function ViewContactDetailsModal({ isOpen, match, onClose }: ViewContactD
             alignItems="center"
             justifyContent="center"
             flexShrink={0}
+            alignSelf={{ base: 'center', lg: 'flex-start' }}
           >
             <Image src="/icons/phone-call.png" alt="Phone" width={24} height={24} />
           </Box>
 
           {/* Content */}
-          <VStack align="stretch" gap={6} flex={1}>
+          <VStack align="stretch" gap={{ base: 4, lg: 6 }} flex={1} w="100%">
             {/* Text and supporting text */}
-            <VStack align="stretch" gap={2}>
+            <VStack align={{ base: 'center', lg: 'stretch' }} gap={2}>
               <Text
-                fontSize="20px"
+                fontSize={{ base: '18px', lg: '20px' }}
                 fontWeight={600}
                 color="#181D27"
                 fontFamily="'Open Sans', sans-serif"
                 lineHeight="1.4em"
+                textAlign={{ base: 'center', lg: 'left' }}
               >
                 {t('yourCallIsSet')}
               </Text>
               <Text
-                fontSize="16px"
+                fontSize={{ base: '14px', lg: '16px' }}
                 fontWeight={400}
                 color="#535862"
                 fontFamily="'Open Sans', sans-serif"
                 lineHeight="1.36181640625em"
+                textAlign={{ base: 'center', lg: 'left' }}
               >
                 {t('youWillGetCall')}
               </Text>
@@ -90,20 +93,20 @@ export function ViewContactDetailsModal({ isOpen, match, onClose }: ViewContactD
             {/* Contact Details */}
             <VStack align="stretch" gap={4}>
               {/* Name */}
-              <HStack gap={4.5} align="center">
+              <HStack gap={{ base: 3, lg: 4.5 }} align="center" flexWrap="wrap">
                 <Text
-                  fontSize="16px"
+                  fontSize={{ base: '14px', lg: '16px' }}
                   fontWeight={600}
                   color="#1D3448"
                   fontFamily="'Open Sans', sans-serif"
                   lineHeight="1.875em"
-                  w="118px"
+                  w={{ base: 'auto', lg: '118px' }}
                   flexShrink={0}
                 >
                   {t('name')}
                 </Text>
                 <Text
-                  fontSize="18px"
+                  fontSize={{ base: '16px', lg: '18px' }}
                   fontWeight={400}
                   color="#056067"
                   fontFamily="'Open Sans', sans-serif"
@@ -114,20 +117,20 @@ export function ViewContactDetailsModal({ isOpen, match, onClose }: ViewContactD
               </HStack>
 
               {/* Phone Number */}
-              <HStack gap={4.5} align="center">
+              <HStack gap={{ base: 3, lg: 4.5 }} align="center" flexWrap="wrap">
                 <Text
-                  fontSize="16px"
+                  fontSize={{ base: '14px', lg: '16px' }}
                   fontWeight={600}
                   color="#1D3448"
                   fontFamily="'Open Sans', sans-serif"
                   lineHeight="1.875em"
-                  w="118px"
+                  w={{ base: 'auto', lg: '118px' }}
                   flexShrink={0}
                 >
                   {t('phoneNumber')}
                 </Text>
                 <Text
-                  fontSize="18px"
+                  fontSize={{ base: '16px', lg: '18px' }}
                   fontWeight={400}
                   color="#056067"
                   fontFamily="'Open Sans', sans-serif"
@@ -139,7 +142,7 @@ export function ViewContactDetailsModal({ isOpen, match, onClose }: ViewContactD
             </VStack>
 
             {/* Action Button */}
-            <Flex justify="flex-end" mt={2}>
+            <Flex justify={{ base: 'stretch', lg: 'flex-end' }} mt={2}>
               <Button
                 bg="#056067"
                 color="white"
@@ -150,6 +153,7 @@ export function ViewContactDetailsModal({ isOpen, match, onClose }: ViewContactD
                 px={4.5}
                 py={2.5}
                 borderRadius="8px"
+                w={{ base: '100%', lg: 'auto' }}
                 onClick={onClose}
                 _hover={{
                   bg: '#044d52',

--- a/frontend/src/components/participant/VolunteerCard.tsx
+++ b/frontend/src/components/participant/VolunteerCard.tsx
@@ -5,6 +5,7 @@ import Badge from '@/components/dashboard/Badge';
 import { COLORS } from '@/constants/form';
 import { FiLoader } from 'react-icons/fi';
 import { useTranslations } from 'next-intl';
+import { useIsDesktop } from '@/hooks/useIsDesktop';
 
 interface VolunteerCardProps {
   match: Match;
@@ -14,6 +15,7 @@ interface VolunteerCardProps {
 export function VolunteerCard({ match, onSchedule }: VolunteerCardProps) {
   const t = useTranslations('dashboard');
   const tOptions = useTranslations('options');
+  const isDesktop = useIsDesktop();
   const { volunteer } = match;
 
   // Helper to translate medical terms with fallback to original value
@@ -37,14 +39,14 @@ export function VolunteerCard({ match, onSchedule }: VolunteerCardProps) {
   return (
     <Box
       w="full"
-      maxW="675px"
+      maxW={{ base: '100%', lg: '675px' }}
       border="1px solid #D5D7DA"
       borderRadius="8px"
       bg="white"
       boxShadow="0 1px 2px 0 rgba(0, 0, 0, 0.05)"
-      py="24px"
-      px="28px"
-      pb="80px"
+      py={{ base: '16px', lg: '24px' }}
+      px={{ base: '16px', lg: '28px' }}
+      pb={{ base: '16px', lg: '80px' }}
       position="relative"
       minH="fit-content"
     >
@@ -52,8 +54,8 @@ export function VolunteerCard({ match, onSchedule }: VolunteerCardProps) {
       {isRequestingNewTimes && (
         <Box
           position="absolute"
-          top="24px"
-          right="28px"
+          top={{ base: '16px', lg: '24px' }}
+          right={{ base: '16px', lg: '28px' }}
           bg="#F5E9E1"
           borderRadius="16px"
           px="12px"
@@ -78,39 +80,44 @@ export function VolunteerCard({ match, onSchedule }: VolunteerCardProps) {
         </Box>
       )}
       <VStack align="start" gap={0}>
-        <HStack gap="32px" align="start">
+        <HStack gap={{ base: '12px', lg: '32px' }} align="start">
           {/* Avatar */}
-          <Avatar name={fullName} size="xl" bg="#F4F4F4" color="#000000" fontSize="36.52px" />
+          <Avatar
+            name={fullName}
+            size={isDesktop ? 'xl' : 'lg'}
+            bg="#F4F4F4"
+            color="#000000"
+            fontSize={isDesktop ? '36.52px' : '24px'}
+          />
 
           {/* Volunteer Info */}
-          <VStack align="start" gap={2}>
-            <HStack gap={2} align="center">
+          <VStack align="start" gap={2} flex={1}>
+            <HStack gap={2} align="center" wrap="wrap">
               <Text
-                fontSize="1.5rem"
+                fontSize={{ base: '1.125rem', lg: '1.5rem' }}
                 fontWeight={600}
                 color="#1D3448"
                 fontFamily="'Open Sans', sans-serif"
-                lineHeight="1.875rem"
+                lineHeight={{ base: '1.5rem', lg: '1.875rem' }}
                 letterSpacing="0%"
               >
                 {fullName}
               </Text>
               {pronounsText && (
                 <Text
-                  fontSize="1rem"
+                  fontSize={{ base: '0.875rem', lg: '1rem' }}
                   fontWeight={400}
                   color="#495D6C"
                   fontFamily="'Open Sans', sans-serif"
                   lineHeight="100%"
                   letterSpacing="0%"
-                  mr="16px"
                 >
                   {pronounsText}
                 </Text>
               )}
             </HStack>
 
-            <HStack gap={2} align="center" wrap="wrap" mt="16px">
+            <HStack gap={2} align="center" wrap="wrap" mt={{ base: '8px', lg: '16px' }}>
               {typeof volunteer.age === 'number' && (
                 <Badge iconSrc="/icons/user-secondary.png">
                   {t('currentAge')} {volunteer.age}
@@ -134,18 +141,18 @@ export function VolunteerCard({ match, onSchedule }: VolunteerCardProps) {
         {volunteer.overview && (
           <Box mt={4}>
             <Text
-              fontSize="1.125rem"
+              fontSize={{ base: '1rem', lg: '1.125rem' }}
               fontWeight={600}
               color="#1D3448"
               fontFamily="'Open Sans', sans-serif"
               lineHeight="1.875rem"
               letterSpacing="0%"
-              mb="16px"
+              mb={{ base: '8px', lg: '16px' }}
             >
               {t('overview')}
             </Text>
             <Text
-              fontSize="1rem"
+              fontSize={{ base: '0.875rem', lg: '1rem' }}
               fontWeight={400}
               color="#495D6C"
               fontFamily="'Open Sans', sans-serif"
@@ -160,13 +167,13 @@ export function VolunteerCard({ match, onSchedule }: VolunteerCardProps) {
         {volunteer.treatments && volunteer.treatments.length > 0 && (
           <Box mt={4}>
             <Text
-              fontSize="1.125rem"
+              fontSize={{ base: '1rem', lg: '1.125rem' }}
               fontWeight={600}
               color="#1D3448"
               fontFamily="'Open Sans', sans-serif"
               lineHeight="1.875rem"
               letterSpacing="0%"
-              mb="16px"
+              mb={{ base: '8px', lg: '16px' }}
             >
               {t('treatmentInformation')}
             </Text>
@@ -184,13 +191,13 @@ export function VolunteerCard({ match, onSchedule }: VolunteerCardProps) {
         {volunteer.experiences && volunteer.experiences.length > 0 && (
           <Box mt={4}>
             <Text
-              fontSize="1.125rem"
+              fontSize={{ base: '1rem', lg: '1.125rem' }}
               fontWeight={600}
               color="#1D3448"
               fontFamily="'Open Sans', sans-serif"
               lineHeight="1.875rem"
               letterSpacing="0%"
-              mb="16px"
+              mb={{ base: '8px', lg: '16px' }}
             >
               {t('experienceInformation')}
             </Text>
@@ -205,12 +212,14 @@ export function VolunteerCard({ match, onSchedule }: VolunteerCardProps) {
         )}
       </VStack>
 
-      {/* Schedule call button - Positioned at bottom right */}
+      {/* Schedule call button */}
       {onSchedule && !isRequestingNewTimes && (
         <Button
-          position="absolute"
-          bottom="24px"
-          right="28px"
+          position={isDesktop ? 'absolute' : 'relative'}
+          bottom={isDesktop ? '24px' : undefined}
+          right={isDesktop ? '28px' : undefined}
+          w={{ base: '100%', lg: 'auto' }}
+          mt={{ base: 4, lg: 0 }}
           bg={COLORS.teal}
           color="white"
           fontWeight={600}

--- a/frontend/src/components/shared/ContactForm.tsx
+++ b/frontend/src/components/shared/ContactForm.tsx
@@ -92,12 +92,12 @@ export function ContactForm({ redirectPath }: ContactFormProps) {
 
   return (
     <>
-      <Box maxW="900px" mx="auto" p={6}>
+      <Box maxW="900px" mx="auto" p={{ base: 4, lg: 6 }}>
         <VStack spacing={6} align="stretch">
           {/* Header */}
           <VStack spacing={2} align="start">
             <Text
-              fontSize="36px"
+              fontSize={{ base: '24px', lg: '36px' }}
               fontWeight={600}
               color="#181D27"
               fontFamily="'Open Sans', sans-serif"
@@ -105,7 +105,7 @@ export function ContactForm({ redirectPath }: ContactFormProps) {
               {t('getInTouch')}
             </Text>
             <Text
-              fontSize="16px"
+              fontSize={{ base: '14px', lg: '16px' }}
               fontWeight={400}
               color="#535862"
               fontFamily="'Open Sans', sans-serif"
@@ -129,7 +129,7 @@ export function ContactForm({ redirectPath }: ContactFormProps) {
               {/* Personal details section */}
               <Box>
                 <Text
-                  fontSize="26px"
+                  fontSize={{ base: '20px', lg: '26px' }}
                   fontWeight={600}
                   color="#1D3448"
                   fontFamily="'Open Sans', sans-serif"
@@ -209,7 +209,7 @@ export function ContactForm({ redirectPath }: ContactFormProps) {
               {/* Message section */}
               <Box>
                 <Text
-                  fontSize="26px"
+                  fontSize={{ base: '20px', lg: '26px' }}
                   fontWeight={600}
                   color="#1D3448"
                   fontFamily="'Open Sans', sans-serif"
@@ -241,16 +241,21 @@ export function ContactForm({ redirectPath }: ContactFormProps) {
               </Box>
 
               {/* Action buttons */}
-              <HStack gap={3} justify="flex-end">
+              <HStack
+                gap={3}
+                justify={{ base: 'stretch', lg: 'flex-end' }}
+                flexDirection={{ base: 'column-reverse', lg: 'row' }}
+              >
                 <Button
                   variant="outline"
                   onClick={handleCancel}
-                  fontSize="18px"
+                  fontSize={{ base: '16px', lg: '18px' }}
                   fontWeight={600}
                   fontFamily="'Open Sans', sans-serif"
-                  px="28px"
-                  py="16px"
+                  px={{ base: '20px', lg: '28px' }}
+                  py={{ base: '14px', lg: '16px' }}
                   h="auto"
+                  w={{ base: '100%', lg: 'auto' }}
                   borderRadius="8px"
                   borderColor="transparent"
                   color="#495D6C"
@@ -264,12 +269,13 @@ export function ContactForm({ redirectPath }: ContactFormProps) {
                   type="submit"
                   bg="#056067"
                   color="white"
-                  fontSize="18px"
+                  fontSize={{ base: '16px', lg: '18px' }}
                   fontWeight={600}
                   fontFamily="'Open Sans', sans-serif"
-                  px="28px"
-                  py="16px"
+                  px={{ base: '20px', lg: '28px' }}
+                  py={{ base: '14px', lg: '16px' }}
                   h="auto"
+                  w={{ base: '100%', lg: 'auto' }}
                   borderRadius="8px"
                   border="1px solid #056067"
                   boxShadow="0px 1px 2px 0px rgba(10, 13, 18, 0.05)"

--- a/frontend/src/components/shared/ContactForm.tsx
+++ b/frontend/src/components/shared/ContactForm.tsx
@@ -93,9 +93,9 @@ export function ContactForm({ redirectPath }: ContactFormProps) {
   return (
     <>
       <Box maxW="900px" mx="auto" p={{ base: 4, lg: 6 }}>
-        <VStack spacing={6} align="stretch">
+        <VStack gap={6} align="stretch">
           {/* Header */}
-          <VStack spacing={2} align="start">
+          <VStack gap={2} align="start">
             <Text
               fontSize={{ base: '24px', lg: '36px' }}
               fontWeight={600}
@@ -138,7 +138,7 @@ export function ContactForm({ redirectPath }: ContactFormProps) {
                   {t('personalDetails')}
                 </Text>
 
-                <Grid templateColumns={{ base: '1fr', md: 'repeat(2, 1fr)' }} gap={4}>
+                <Grid templateColumns={{ base: '1fr', lg: 'repeat(2, 1fr)' }} gap={4}>
                   {/* Name field */}
                   <Field
                     label={

--- a/frontend/src/pages/faq.tsx
+++ b/frontend/src/pages/faq.tsx
@@ -55,16 +55,15 @@ export default function FAQPage() {
 
   return (
     <div className="flex min-h-screen bg-white">
-      <div className="flex-1 p-6">
-        <div className="mx-auto" style={{ width: '620px' }}>
+      <div className="flex-1 p-4 lg:p-6">
+        <div className="mx-auto w-full max-w-[620px]">
           <h1
-            className="font-semibold"
+            className="font-semibold text-2xl lg:text-4xl"
             style={{
               color: COLORS.veniceBlue,
-              fontSize: '36px',
               letterSpacing: '-0.5px',
               fontFamily: 'Open Sans, sans-serif',
-              marginBottom: '48px',
+              marginBottom: '32px',
             }}
           >
             {t('frequentlyAskedQuestions')}
@@ -91,12 +90,12 @@ export default function FAQPage() {
                         isOpen ? prev.filter((id) => id !== faq.id) : [...prev, faq.id],
                       )
                     }
-                    className="w-full flex items-center justify-between py-4 px-5 bg-transparent border-none rounded-lg cursor-pointer text-left hover:bg-gray-50"
+                    className="w-full flex items-center justify-between py-4 px-4 lg:px-5 bg-transparent border-none rounded-lg cursor-pointer text-left hover:bg-gray-50"
                   >
                     <span
+                      className="text-base lg:text-lg"
                       style={{
                         color: COLORS.veniceBlue,
-                        fontSize: '18px',
                         fontWeight: 600,
                         fontFamily: 'Open Sans, sans-serif',
                       }}
@@ -104,18 +103,25 @@ export default function FAQPage() {
                       {faq.question}
                     </span>
                     {isOpen ? (
-                      <FiChevronUp color={COLORS.veniceBlue} size={24} />
+                      <FiChevronUp
+                        color={COLORS.veniceBlue}
+                        size={24}
+                        className="flex-shrink-0 ml-2"
+                      />
                     ) : (
-                      <FiChevronDown color={COLORS.veniceBlue} size={24} />
+                      <FiChevronDown
+                        color={COLORS.veniceBlue}
+                        size={24}
+                        className="flex-shrink-0 ml-2"
+                      />
                     )}
                   </button>
                   {isOpen && (
-                    <div className="px-5 pb-4">
+                    <div className="px-4 lg:px-5 pb-4">
                       <div
-                        className="mb-4 whitespace-pre-wrap"
+                        className="mb-4 whitespace-pre-wrap text-sm lg:text-base"
                         style={{
                           color: COLORS.veniceBlue,
-                          fontSize: '16px',
                           fontWeight: 400,
                           fontFamily: 'Open Sans, sans-serif',
                         }}
@@ -125,7 +131,7 @@ export default function FAQPage() {
                       {faq.actionButton && (
                         <button
                           onClick={faq.actionButton.action}
-                          className="inline-flex items-center justify-center font-medium cursor-pointer text-white"
+                          className="inline-flex items-center justify-center font-medium cursor-pointer text-white w-full lg:w-auto"
                           style={{
                             backgroundColor: ACCENT_COLOR,
                             border: `1px solid ${ACCENT_COLOR}`,

--- a/frontend/src/pages/faq.tsx
+++ b/frontend/src/pages/faq.tsx
@@ -3,6 +3,11 @@ import { FiChevronDown, FiChevronUp } from 'react-icons/fi';
 import { COLORS } from '@/constants/form';
 import { useRouter } from 'next/router';
 import { useTranslations } from 'next-intl';
+import { MobileHeader } from '@/components/layout/MobileHeader';
+import { MobileDrawer } from '@/components/layout/MobileDrawer';
+import type { NavItem } from '@/components/layout/MobileDrawer';
+import { useIsDesktop } from '@/hooks/useIsDesktop';
+import { getCurrentUser } from '@/APIClients/authAPIClient';
 
 interface FAQItem {
   id: string;
@@ -20,8 +25,28 @@ const SHADOW_COLOR = '#B3CED1';
 
 export default function FAQPage() {
   const [expandedFAQs, setExpandedFAQs] = useState<string[]>([]);
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const router = useRouter();
   const t = useTranslations('dashboard');
+  const isDesktop = useIsDesktop();
+
+  const user = typeof window !== 'undefined' ? getCurrentUser() : null;
+  const userName = user
+    ? `${user.firstName || ''} ${user.lastName || ''}`.trim() || user.email
+    : '';
+
+  const navItems: NavItem[] = [
+    {
+      label: t('matches'),
+      path: '/participant/dashboard',
+      isActive: false,
+    },
+    {
+      label: t('contact'),
+      path: '/participant/dashboard/contact',
+      isActive: false,
+    },
+  ];
 
   const faqData: FAQItem[] = [
     {
@@ -54,7 +79,20 @@ export default function FAQPage() {
   ];
 
   return (
-    <div className="flex min-h-screen bg-white">
+    <div className="flex flex-col min-h-screen bg-white">
+      {/* Mobile Header */}
+      {!isDesktop && (
+        <MobileHeader userName={userName} onMenuOpen={() => setIsMobileMenuOpen(true)} />
+      )}
+
+      {/* Mobile Drawer */}
+      <MobileDrawer
+        isOpen={isMobileMenuOpen}
+        onClose={() => setIsMobileMenuOpen(false)}
+        userName={userName}
+        navItems={navItems}
+      />
+
       <div className="flex-1 p-4 lg:p-6">
         <div className="mx-auto w-full max-w-[620px]">
           <h1

--- a/frontend/src/pages/participant/dashboard.tsx
+++ b/frontend/src/pages/participant/dashboard.tsx
@@ -16,7 +16,10 @@ import { FiPlus } from 'react-icons/fi';
 import { useTranslations } from 'next-intl';
 import { ProtectedPage } from '@/components/auth/ProtectedPage';
 import { FormStatusGuard } from '@/components/auth/FormStatusGuard';
-import { DashboardSidebar } from '@/components/participant/DashboardSidebar';
+import {
+  DashboardSidebar,
+  useParticipantNavItems,
+} from '@/components/participant/DashboardSidebar';
 import { VolunteerCard } from '@/components/participant/VolunteerCard';
 import { ConfirmedMatchCard } from '@/components/participant/ConfirmedMatchCard';
 import { RequestNewMatchesModal } from '@/components/participant/RequestNewMatchesModal';
@@ -25,16 +28,21 @@ import { ViewContactDetailsModal } from '@/components/participant/ViewContactDet
 import { CancelCallConfirmationModal } from '@/components/participant/CancelCallConfirmationModal';
 import { CancelCallSuccessModal } from '@/components/participant/CancelCallSuccessModal';
 import ParticipantEditProfileModal from '@/components/participant/ParticipantEditProfileModal';
+import { MobileHeader } from '@/components/layout/MobileHeader';
+import { MobileDrawer } from '@/components/layout/MobileDrawer';
 import { Avatar } from '@/components/ui/avatar';
 import { participantMatchAPIClient } from '@/APIClients/participantMatchAPIClient';
 import { getCurrentUser } from '@/APIClients/authAPIClient';
 import { AuthenticatedUser, FormStatus, UserRole } from '@/types/authTypes';
 import { Match } from '@/types/matchTypes';
 import { MatchStatusScreen } from '@/components/matches/MatchStatusScreen';
+import { useIsDesktop } from '@/hooks/useIsDesktop';
 
 export default function ParticipantDashboardPage() {
   const t = useTranslations('dashboard');
   const router = useRouter();
+  const isDesktop = useIsDesktop();
+  const navItems = useParticipantNavItems();
   const [matches, setMatches] = useState<Match[]>([]);
   const [confirmedMatches, setConfirmedMatches] = useState<Match[]>([]);
   const [allMatches, setAllMatches] = useState<Match[]>([]);
@@ -53,6 +61,7 @@ export default function ParticipantDashboardPage() {
   const [requestMessage, setRequestMessage] = useState('');
   const [user, setUser] = useState<AuthenticatedUser | null>(null);
   const [isEditProfileOpen, setIsEditProfileOpen] = useState(false);
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   const userName = user?.firstName || 'there';
   const userFullName = user
@@ -316,146 +325,186 @@ export default function ParticipantDashboardPage() {
   return (
     <ProtectedPage allowedRoles={[UserRole.PARTICIPANT, UserRole.ADMIN]}>
       <FormStatusGuard allowedStatuses={[FormStatus.COMPLETED]}>
-        <Box minH="100vh" bg="white" py={10}>
-          <Container maxW="container.xl">
-            <Flex
-              direction={{ base: 'column', lg: 'row' }}
-              align="flex-start"
-              gap={{ base: 8, lg: 12 }}
-            >
-              <DashboardSidebar />
+        <Box minH="100vh" bg="white">
+          {/* Mobile Header */}
+          {!isDesktop && (
+            <MobileHeader
+              userName={userFullName}
+              onMenuOpen={() => setIsMobileMenuOpen(true)}
+              onAvatarClick={() => setIsEditProfileOpen(true)}
+            />
+          )}
 
-              <Box flex={1} w="full">
-                <VStack align="stretch" gap={6}>
-                  {/* Header */}
-                  {hasPendingRequest ? (
-                    <Flex justify="space-between" align="flex-start">
-                      <Box flex={1}>
-                        <Heading fontSize="2xl" fontWeight="600" color="#1F2937" mb={2}>
-                          {t('yourRequestIsPending')}
-                        </Heading>
-                        <Text fontSize="md" color="#6B7280" opacity={0.85}>
-                          {t('checkBackInFewDays')}
-                        </Text>
-                      </Box>
-                      {/* User Avatar in top right */}
-                      {user && (
-                        <Box
-                          flexShrink={0}
-                          ml={4}
-                          cursor="pointer"
-                          onClick={() => setIsEditProfileOpen(true)}
-                          _hover={{ opacity: 0.8 }}
-                          transition="opacity 0.2s"
-                        >
-                          <Avatar
-                            name={userFullName}
-                            size="lg"
-                            bg="rgba(179, 206, 209, 0.3)"
-                            color="#056067"
-                            fontWeight={500}
-                          />
-                        </Box>
-                      )}
-                    </Flex>
-                  ) : confirmedMatches.length > 0 ? (
-                    <Flex justify="space-between" align="flex-start">
-                      <Box flex={1}>
-                        <Heading fontSize="2xl" fontWeight="600" color="#1F2937" mb={2}>
-                          {t('thanksForScheduling')}
-                        </Heading>
-                        <Text fontSize="md" color="#6B7280" opacity={0.85}>
-                          {t('viewContactDetails')}
-                        </Text>
-                      </Box>
-                      {/* User Avatar in top right */}
-                      {user && (
-                        <Box
-                          flexShrink={0}
-                          ml={4}
-                          cursor="pointer"
-                          onClick={() => setIsEditProfileOpen(true)}
-                          _hover={{ opacity: 0.8 }}
-                          transition="opacity 0.2s"
-                        >
-                          <Avatar
-                            name={userFullName}
-                            size="lg"
-                            bg="rgba(179, 206, 209, 0.3)"
-                            color="#056067"
-                            fontWeight={500}
-                          />
-                        </Box>
-                      )}
-                    </Flex>
-                  ) : confirmedMatches.length === 0 && matches.length === 0 ? (
-                    <Flex justify="space-between" align="flex-start">
-                      <Box flex={1}>
-                        <Heading fontSize="2xl" fontWeight="600" color="#1F2937" mb={2}>
-                          {t('requestNewVolunteers')}
-                        </Heading>
-                        <Text fontSize="md" color="#6B7280" opacity={0.85}>
-                          {t('wouldYouLikeNewMatches')}
-                        </Text>
-                      </Box>
-                      {/* User Avatar in top right */}
-                      {user && (
-                        <Box
-                          flexShrink={0}
-                          ml={4}
-                          cursor="pointer"
-                          onClick={() => setIsEditProfileOpen(true)}
-                          _hover={{ opacity: 0.8 }}
-                          transition="opacity 0.2s"
-                        >
-                          <Avatar
-                            name={userFullName}
-                            size="lg"
-                            bg="rgba(179, 206, 209, 0.3)"
-                            color="#056067"
-                            fontWeight={500}
-                          />
-                        </Box>
-                      )}
-                    </Flex>
-                  ) : (
-                    <Flex justify="space-between" align="flex-start">
-                      <Box flex={1}>
-                        <Heading fontSize="2xl" fontWeight="600" color="#1F2937" mb={2}>
-                          {t('whoWouldYouLikeToChat', { name: userName })}
-                        </Heading>
-                        <Text fontSize="md" color="#6B7280" opacity={0.85}>
-                          {t('carefullySelectedVolunteers')}
-                        </Text>
-                      </Box>
-                      {/* User Avatar in top right */}
-                      {user && (
-                        <Box
-                          flexShrink={0}
-                          ml={4}
-                          cursor="pointer"
-                          onClick={() => setIsEditProfileOpen(true)}
-                          _hover={{ opacity: 0.8 }}
-                          transition="opacity 0.2s"
-                        >
-                          <Avatar
-                            name={userFullName}
-                            size="lg"
-                            bg="rgba(179, 206, 209, 0.3)"
-                            color="#056067"
-                            fontWeight={500}
-                          />
-                        </Box>
-                      )}
-                    </Flex>
-                  )}
+          {/* Mobile Drawer */}
+          <MobileDrawer
+            isOpen={isMobileMenuOpen}
+            onClose={() => setIsMobileMenuOpen(false)}
+            userName={userFullName}
+            navItems={navItems}
+            onEditProfile={() => setIsEditProfileOpen(true)}
+          />
 
-                  {/* Content */}
-                  {renderMatchesTab()}
-                </VStack>
-              </Box>
-            </Flex>
-          </Container>
+          <Box py={{ base: 4, lg: 10 }}>
+            <Container maxW="container.xl" px={{ base: 4, lg: 8 }}>
+              <Flex
+                direction={{ base: 'column', lg: 'row' }}
+                align="flex-start"
+                gap={{ base: 6, lg: 12 }}
+              >
+                <DashboardSidebar />
+
+                <Box flex={1} w="full">
+                  <VStack align="stretch" gap={6}>
+                    {/* Header */}
+                    {hasPendingRequest ? (
+                      <Flex justify="space-between" align="flex-start">
+                        <Box flex={1}>
+                          <Heading
+                            fontSize={{ base: 'xl', lg: '2xl' }}
+                            fontWeight="600"
+                            color="#1F2937"
+                            mb={2}
+                          >
+                            {t('yourRequestIsPending')}
+                          </Heading>
+                          <Text fontSize={{ base: 'sm', lg: 'md' }} color="#6B7280" opacity={0.85}>
+                            {t('checkBackInFewDays')}
+                          </Text>
+                        </Box>
+                        {/* User Avatar in top right - desktop only */}
+                        {user && isDesktop && (
+                          <Box
+                            flexShrink={0}
+                            ml={4}
+                            cursor="pointer"
+                            onClick={() => setIsEditProfileOpen(true)}
+                            _hover={{ opacity: 0.8 }}
+                            transition="opacity 0.2s"
+                          >
+                            <Avatar
+                              name={userFullName}
+                              size="lg"
+                              bg="rgba(179, 206, 209, 0.3)"
+                              color="#056067"
+                              fontWeight={500}
+                            />
+                          </Box>
+                        )}
+                      </Flex>
+                    ) : confirmedMatches.length > 0 ? (
+                      <Flex justify="space-between" align="flex-start">
+                        <Box flex={1}>
+                          <Heading
+                            fontSize={{ base: 'xl', lg: '2xl' }}
+                            fontWeight="600"
+                            color="#1F2937"
+                            mb={2}
+                          >
+                            {t('thanksForScheduling')}
+                          </Heading>
+                          <Text fontSize={{ base: 'sm', lg: 'md' }} color="#6B7280" opacity={0.85}>
+                            {t('viewContactDetails')}
+                          </Text>
+                        </Box>
+                        {/* User Avatar in top right - desktop only */}
+                        {user && isDesktop && (
+                          <Box
+                            flexShrink={0}
+                            ml={4}
+                            cursor="pointer"
+                            onClick={() => setIsEditProfileOpen(true)}
+                            _hover={{ opacity: 0.8 }}
+                            transition="opacity 0.2s"
+                          >
+                            <Avatar
+                              name={userFullName}
+                              size="lg"
+                              bg="rgba(179, 206, 209, 0.3)"
+                              color="#056067"
+                              fontWeight={500}
+                            />
+                          </Box>
+                        )}
+                      </Flex>
+                    ) : confirmedMatches.length === 0 && matches.length === 0 ? (
+                      <Flex justify="space-between" align="flex-start">
+                        <Box flex={1}>
+                          <Heading
+                            fontSize={{ base: 'xl', lg: '2xl' }}
+                            fontWeight="600"
+                            color="#1F2937"
+                            mb={2}
+                          >
+                            {t('requestNewVolunteers')}
+                          </Heading>
+                          <Text fontSize={{ base: 'sm', lg: 'md' }} color="#6B7280" opacity={0.85}>
+                            {t('wouldYouLikeNewMatches')}
+                          </Text>
+                        </Box>
+                        {/* User Avatar in top right - desktop only */}
+                        {user && isDesktop && (
+                          <Box
+                            flexShrink={0}
+                            ml={4}
+                            cursor="pointer"
+                            onClick={() => setIsEditProfileOpen(true)}
+                            _hover={{ opacity: 0.8 }}
+                            transition="opacity 0.2s"
+                          >
+                            <Avatar
+                              name={userFullName}
+                              size="lg"
+                              bg="rgba(179, 206, 209, 0.3)"
+                              color="#056067"
+                              fontWeight={500}
+                            />
+                          </Box>
+                        )}
+                      </Flex>
+                    ) : (
+                      <Flex justify="space-between" align="flex-start">
+                        <Box flex={1}>
+                          <Heading
+                            fontSize={{ base: 'xl', lg: '2xl' }}
+                            fontWeight="600"
+                            color="#1F2937"
+                            mb={2}
+                          >
+                            {t('whoWouldYouLikeToChat', { name: userName })}
+                          </Heading>
+                          <Text fontSize={{ base: 'sm', lg: 'md' }} color="#6B7280" opacity={0.85}>
+                            {t('carefullySelectedVolunteers')}
+                          </Text>
+                        </Box>
+                        {/* User Avatar in top right - desktop only */}
+                        {user && isDesktop && (
+                          <Box
+                            flexShrink={0}
+                            ml={4}
+                            cursor="pointer"
+                            onClick={() => setIsEditProfileOpen(true)}
+                            _hover={{ opacity: 0.8 }}
+                            transition="opacity 0.2s"
+                          >
+                            <Avatar
+                              name={userFullName}
+                              size="lg"
+                              bg="rgba(179, 206, 209, 0.3)"
+                              color="#056067"
+                              fontWeight={500}
+                            />
+                          </Box>
+                        )}
+                      </Flex>
+                    )}
+
+                    {/* Content */}
+                    {renderMatchesTab()}
+                  </VStack>
+                </Box>
+              </Flex>
+            </Container>
+          </Box>
         </Box>
 
         {/* Modals */}

--- a/frontend/src/pages/participant/dashboard.tsx
+++ b/frontend/src/pages/participant/dashboard.tsx
@@ -289,11 +289,31 @@ export default function ParticipantDashboardPage() {
     // Show status screen with all matches
     return (
       <VStack align="stretch" gap={6}>
-        <MatchStatusScreen
-          matches={allMatches}
-          userRole={UserRole.PARTICIPANT}
-          userName={userName}
-        />
+        {/* Mobile: show cards directly; Desktop: show table view */}
+        {!isDesktop ? (
+          <VStack align="stretch" gap={6}>
+            {/* Pending/Requesting matches - show VolunteerCards */}
+            {matches.map((match) => (
+              <VolunteerCard key={match.id} match={match} onSchedule={handleSchedule} />
+            ))}
+
+            {/* Confirmed matches - show ConfirmedMatchCards */}
+            {confirmedMatches.map((match) => (
+              <ConfirmedMatchCard
+                key={match.id}
+                match={match}
+                onCancelCall={handleCancelCall}
+                onViewContactDetails={handleViewContactDetails}
+              />
+            ))}
+          </VStack>
+        ) : (
+          <MatchStatusScreen
+            matches={allMatches}
+            userRole={UserRole.PARTICIPANT}
+            userName={userName}
+          />
+        )}
 
         {/* Request New Matches Button */}
         <Button
@@ -309,6 +329,7 @@ export default function ParticipantDashboardPage() {
           lineHeight="1.5em"
           fontFamily="Open Sans, sans-serif"
           boxShadow="0px 1px 2px 0px rgba(10, 13, 18, 0.05)"
+          w={{ base: '100%', lg: 'auto' }}
           _hover={{ bg: '#044d52', borderColor: '#044d52' }}
           _active={{ bg: '#033a3e', borderColor: '#033a3e' }}
           onClick={handleRequestNewMatchesClick}

--- a/frontend/src/pages/participant/dashboard/contact.tsx
+++ b/frontend/src/pages/participant/dashboard/contact.tsx
@@ -2,16 +2,25 @@ import { useEffect, useState } from 'react';
 import { Box, Container, Flex } from '@chakra-ui/react';
 import { ProtectedPage } from '@/components/auth/ProtectedPage';
 import { FormStatusGuard } from '@/components/auth/FormStatusGuard';
-import { DashboardSidebar } from '@/components/participant/DashboardSidebar';
+import {
+  DashboardSidebar,
+  useParticipantNavItems,
+} from '@/components/participant/DashboardSidebar';
 import { ContactForm } from '@/components/shared/ContactForm';
 import ParticipantEditProfileModal from '@/components/participant/ParticipantEditProfileModal';
+import { MobileHeader } from '@/components/layout/MobileHeader';
+import { MobileDrawer } from '@/components/layout/MobileDrawer';
 import { Avatar } from '@/components/ui/avatar';
 import { getCurrentUser } from '@/APIClients/authAPIClient';
 import { AuthenticatedUser, FormStatus, UserRole } from '@/types/authTypes';
+import { useIsDesktop } from '@/hooks/useIsDesktop';
 
 export default function ParticipantContactPage() {
+  const isDesktop = useIsDesktop();
+  const navItems = useParticipantNavItems();
   const [user, setUser] = useState<AuthenticatedUser | null>(null);
   const [isEditProfileOpen, setIsEditProfileOpen] = useState(false);
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -26,41 +35,61 @@ export default function ParticipantContactPage() {
   return (
     <ProtectedPage allowedRoles={[UserRole.PARTICIPANT, UserRole.ADMIN]}>
       <FormStatusGuard allowedStatuses={[FormStatus.COMPLETED]}>
-        <Box minH="100vh" bg="white" py={10}>
-          <Container maxW="container.xl">
-            <Flex
-              direction={{ base: 'column', lg: 'row' }}
-              align="flex-start"
-              gap={{ base: 8, lg: 12 }}
-            >
-              <DashboardSidebar />
+        <Box minH="100vh" bg="white">
+          {/* Mobile Header */}
+          {!isDesktop && (
+            <MobileHeader
+              userName={userName}
+              onMenuOpen={() => setIsMobileMenuOpen(true)}
+              onAvatarClick={() => setIsEditProfileOpen(true)}
+            />
+          )}
 
-              <Box flex={1} w="full">
-                {/* User Avatar in top right */}
-                {user && (
-                  <Flex justify="flex-end" mb={6}>
-                    <Box
-                      cursor="pointer"
-                      onClick={() => setIsEditProfileOpen(true)}
-                      _hover={{ opacity: 0.8 }}
-                      transition="opacity 0.2s"
-                    >
-                      <Avatar
-                        name={userName}
-                        size="lg"
-                        bg="rgba(179, 206, 209, 0.3)"
-                        color="#056067"
-                        fontWeight={500}
-                      />
-                    </Box>
-                  </Flex>
-                )}
+          {/* Mobile Drawer */}
+          <MobileDrawer
+            isOpen={isMobileMenuOpen}
+            onClose={() => setIsMobileMenuOpen(false)}
+            userName={userName}
+            navItems={navItems}
+            onEditProfile={() => setIsEditProfileOpen(true)}
+          />
 
-                {/* Contact Form */}
-                <ContactForm redirectPath="/participant/dashboard" />
-              </Box>
-            </Flex>
-          </Container>
+          <Box py={{ base: 4, lg: 10 }}>
+            <Container maxW="container.xl" px={{ base: 4, lg: 8 }}>
+              <Flex
+                direction={{ base: 'column', lg: 'row' }}
+                align="flex-start"
+                gap={{ base: 6, lg: 12 }}
+              >
+                <DashboardSidebar />
+
+                <Box flex={1} w="full">
+                  {/* User Avatar in top right - desktop only */}
+                  {user && isDesktop && (
+                    <Flex justify="flex-end" mb={6}>
+                      <Box
+                        cursor="pointer"
+                        onClick={() => setIsEditProfileOpen(true)}
+                        _hover={{ opacity: 0.8 }}
+                        transition="opacity 0.2s"
+                      >
+                        <Avatar
+                          name={userName}
+                          size="lg"
+                          bg="rgba(179, 206, 209, 0.3)"
+                          color="#056067"
+                          fontWeight={500}
+                        />
+                      </Box>
+                    </Flex>
+                  )}
+
+                  {/* Contact Form */}
+                  <ContactForm redirectPath="/participant/dashboard" />
+                </Box>
+              </Flex>
+            </Container>
+          </Box>
         </Box>
 
         {/* Edit Profile Modal */}

--- a/frontend/src/pages/participant/request-new-times/[matchId].tsx
+++ b/frontend/src/pages/participant/request-new-times/[matchId].tsx
@@ -12,6 +12,7 @@ import { FormStatus, UserRole } from '@/types/authTypes';
 import { Match } from '@/types/matchTypes';
 import type { TimeSlot } from '@/components/dashboard/types';
 import { useTranslations } from 'next-intl';
+import { useIsDesktop } from '@/hooks/useIsDesktop';
 
 type Step = 'select-days' | 'select-times';
 
@@ -19,6 +20,7 @@ export default function RequestNewTimesPage() {
   const t = useTranslations('dashboard');
   const router = useRouter();
   const { matchId } = router.query;
+  const isDesktop = useIsDesktop();
 
   const [match, setMatch] = useState<Match | null>(null);
   const [loading, setLoading] = useState(true);
@@ -203,9 +205,9 @@ export default function RequestNewTimesPage() {
   return (
     <ProtectedPage allowedRoles={[UserRole.PARTICIPANT, UserRole.ADMIN]}>
       <FormStatusGuard allowedStatuses={[FormStatus.COMPLETED]}>
-        <Box minH="100vh" bg="white" py={10}>
-          <Container maxW="container.xl">
-            <VStack align="stretch" gap={8}>
+        <Box minH="100vh" bg="white" py={{ base: 4, lg: 10 }}>
+          <Container maxW="container.xl" px={{ base: 4, lg: 8 }}>
+            <VStack align="stretch" gap={{ base: 6, lg: 8 }}>
               {/* Back button */}
               <Flex
                 align="center"
@@ -233,9 +235,9 @@ export default function RequestNewTimesPage() {
               </Flex>
 
               {/* Header */}
-              <VStack align="stretch" gap={4}>
+              <VStack align="stretch" gap={{ base: 2, lg: 4 }}>
                 <Heading
-                  fontSize="36px"
+                  fontSize={{ base: '24px', lg: '36px' }}
                   fontWeight={600}
                   color="#1D3448"
                   fontFamily="'Open Sans', sans-serif"
@@ -245,7 +247,7 @@ export default function RequestNewTimesPage() {
                   {t('requestNewTime')}
                 </Heading>
                 <Text
-                  fontSize="18px"
+                  fontSize={{ base: '14px', lg: '18px' }}
                   fontWeight={400}
                   color="#1D3448"
                   fontFamily="'Open Sans', sans-serif"
@@ -259,23 +261,24 @@ export default function RequestNewTimesPage() {
 
               {/* Step 1: Select Days */}
               {step === 'select-days' && (
-                <VStack align="stretch" gap={8}>
+                <VStack align="stretch" gap={{ base: 6, lg: 8 }}>
                   <DaySelectionCalendar
                     selectedDays={selectedDays}
                     onDaysChange={setSelectedDays}
                     maxDays={7}
                   />
-                  <Flex justify="flex-end">
+                  <Flex justify={{ base: 'stretch', lg: 'flex-end' }}>
                     <Button
                       bg="#056067"
                       color="white"
                       fontWeight={600}
-                      fontSize="20px"
+                      fontSize={{ base: '16px', lg: '20px' }}
                       fontFamily="'Open Sans', sans-serif"
                       lineHeight="1em"
-                      px={10.5}
+                      px={{ base: 6, lg: 10.5 }}
                       py={4.5}
                       borderRadius="8px"
+                      w={{ base: '100%', lg: 'auto' }}
                       onClick={handleDaysSelected}
                       disabled={selectedDays.length === 0}
                       _hover={{
@@ -293,21 +296,55 @@ export default function RequestNewTimesPage() {
 
               {/* Step 2: Select Times */}
               {step === 'select-times' && (
-                <VStack align="stretch" gap={8}>
+                <VStack align="stretch" gap={{ base: 6, lg: 8 }}>
                   {/* Time Scheduler - Show only selected days */}
-                  <Box h="900px" w="100%">
-                    <TimeScheduler
-                      onTimeSlotsChange={setSelectedTimeSlots}
-                      initialTimeSlots={selectedTimeSlots}
-                      readOnly={false}
-                      visibleDays={selectedDays.map((day) =>
-                        day.toLocaleDateString('en-US', { weekday: 'long' }),
-                      )}
-                      selectedDaysDates={selectedDays}
-                    />
-                  </Box>
+                  {/* Note: TimeScheduler needs mobile-friendly alternative, for now show message on mobile */}
+                  {isDesktop ? (
+                    <Box h="900px" w="100%">
+                      <TimeScheduler
+                        onTimeSlotsChange={setSelectedTimeSlots}
+                        initialTimeSlots={selectedTimeSlots}
+                        readOnly={false}
+                        visibleDays={selectedDays.map((day) =>
+                          day.toLocaleDateString('en-US', { weekday: 'long' }),
+                        )}
+                        selectedDaysDates={selectedDays}
+                      />
+                    </Box>
+                  ) : (
+                    <Box
+                      minH="400px"
+                      w="100%"
+                      overflowX="auto"
+                      css={{
+                        '&::-webkit-scrollbar': {
+                          height: '8px',
+                        },
+                        '&::-webkit-scrollbar-thumb': {
+                          background: '#CBD5E0',
+                          borderRadius: '4px',
+                        },
+                      }}
+                    >
+                      <Box minW="600px">
+                        <TimeScheduler
+                          onTimeSlotsChange={setSelectedTimeSlots}
+                          initialTimeSlots={selectedTimeSlots}
+                          readOnly={false}
+                          visibleDays={selectedDays.map((day) =>
+                            day.toLocaleDateString('en-US', { weekday: 'long' }),
+                          )}
+                          selectedDaysDates={selectedDays}
+                        />
+                      </Box>
+                    </Box>
+                  )}
 
-                  <Flex justify="flex-end" gap={3}>
+                  <Flex
+                    justify={{ base: 'stretch', lg: 'flex-end' }}
+                    gap={3}
+                    direction={{ base: 'column-reverse', lg: 'row' }}
+                  >
                     <Button
                       bg="rgba(179, 206, 209, 0.3)"
                       color="#495D6C"
@@ -318,6 +355,7 @@ export default function RequestNewTimesPage() {
                       px={4.5}
                       py={2.5}
                       borderRadius="8px"
+                      w={{ base: '100%', lg: 'auto' }}
                       onClick={handleBackFromTimes}
                       _hover={{
                         bg: 'rgba(179, 206, 209, 0.4)',
@@ -329,12 +367,13 @@ export default function RequestNewTimesPage() {
                       bg="#056067"
                       color="white"
                       fontWeight={600}
-                      fontSize="20px"
+                      fontSize={{ base: '16px', lg: '20px' }}
                       fontFamily="'Open Sans', sans-serif"
                       lineHeight="1em"
-                      px={10.5}
+                      px={{ base: 6, lg: 10.5 }}
                       py={4.5}
                       borderRadius="8px"
+                      w={{ base: '100%', lg: 'auto' }}
                       onClick={handleTimesSelected}
                       disabled={selectedTimeSlots.length === 0 || isSubmitting}
                       loading={isSubmitting}

--- a/frontend/src/pages/participant/request-new-times/[matchId].tsx
+++ b/frontend/src/pages/participant/request-new-times/[matchId].tsx
@@ -242,7 +242,7 @@ export default function RequestNewTimesPage() {
                   color="#1D3448"
                   fontFamily="'Open Sans', sans-serif"
                   lineHeight="1.36181640625em"
-                  letterSpacing="-1.5%"
+                  letterSpacing="-0.015em"
                 >
                   {t('requestNewTime')}
                 </Heading>
@@ -252,7 +252,7 @@ export default function RequestNewTimesPage() {
                   color="#1D3448"
                   fontFamily="'Open Sans', sans-serif"
                   lineHeight="1.36181640625em"
-                  letterSpacing="-1.5%"
+                  letterSpacing="-0.015em"
                   opacity={0.85}
                 >
                   {t('ifTimesDoNotWork')}

--- a/frontend/src/pages/participant/schedule/[matchId].tsx
+++ b/frontend/src/pages/participant/schedule/[matchId].tsx
@@ -7,6 +7,7 @@ import { participantMatchAPIClient } from '@/APIClients/participantMatchAPIClien
 import { FormStatus, UserRole } from '@/types/authTypes';
 import { Match, TimeBlock } from '@/types/matchTypes';
 import { useTranslations } from 'next-intl';
+import { useIsDesktop } from '@/hooks/useIsDesktop';
 
 interface GroupedTimeBlocks {
   [date: string]: TimeBlock[];
@@ -16,6 +17,7 @@ export default function ScheduleCallPage() {
   const t = useTranslations('dashboard');
   const router = useRouter();
   const { matchId } = router.query;
+  const isDesktop = useIsDesktop();
 
   const [match, setMatch] = useState<Match | null>(null);
   const [loading, setLoading] = useState(true);
@@ -157,9 +159,9 @@ export default function ScheduleCallPage() {
   return (
     <ProtectedPage allowedRoles={[UserRole.PARTICIPANT, UserRole.ADMIN]}>
       <FormStatusGuard allowedStatuses={[FormStatus.COMPLETED]}>
-        <Box minH="100vh" bg="white" py={10}>
-          <Container maxW="container.md">
-            <VStack align="stretch" gap={8}>
+        <Box minH="100vh" bg="white" py={{ base: 4, lg: 10 }}>
+          <Container maxW="container.md" px={{ base: 4, lg: 8 }}>
+            <VStack align="stretch" gap={{ base: 6, lg: 8 }}>
               {/* Back button */}
               <Flex
                 align="center"
@@ -189,14 +191,18 @@ export default function ScheduleCallPage() {
               {/* Header */}
               <VStack align="stretch" gap={2}>
                 <Heading
-                  fontSize="2xl"
+                  fontSize={{ base: 'xl', lg: '2xl' }}
                   fontWeight="600"
                   color="#1D3448"
                   fontFamily="'Open Sans', sans-serif"
                 >
                   {t('scheduleYourCall', { name: volunteerName })}
                 </Heading>
-                <Text fontSize="md" color="#6B7280" fontFamily="'Open Sans', sans-serif">
+                <Text
+                  fontSize={{ base: 'sm', lg: 'md' }}
+                  color="#6B7280"
+                  fontFamily="'Open Sans', sans-serif"
+                >
                   {t('whenWouldYouLikeToMeet')}
                 </Text>
               </VStack>
@@ -204,14 +210,14 @@ export default function ScheduleCallPage() {
               {/* Date Selection */}
               <VStack align="stretch" gap={4}>
                 <Text
-                  fontSize="md"
+                  fontSize={{ base: 'sm', lg: 'md' }}
                   fontWeight="600"
                   color="#1D3448"
                   fontFamily="'Open Sans', sans-serif"
                 >
                   {t('selectDate')}
                 </Text>
-                <Flex gap={3} flexWrap="wrap">
+                <VStack gap={3} align="stretch">
                   {sortedDates.map((dateKey) => (
                     <Button
                       key={dateKey}
@@ -230,6 +236,8 @@ export default function ScheduleCallPage() {
                       px={6}
                       py={6}
                       borderRadius="6px"
+                      w={{ base: '100%', lg: 'auto' }}
+                      justifyContent={{ base: 'center', lg: 'center' }}
                       _hover={{
                         borderColor: '#056067',
                       }}
@@ -237,7 +245,7 @@ export default function ScheduleCallPage() {
                       {formatDate(dateKey)}
                     </Button>
                   ))}
-                </Flex>
+                </VStack>
               </VStack>
 
               {/* Time Selection */}
@@ -245,14 +253,18 @@ export default function ScheduleCallPage() {
                 <VStack align="stretch" gap={4}>
                   <Box>
                     <Text
-                      fontSize="md"
+                      fontSize={{ base: 'sm', lg: 'md' }}
                       fontWeight="600"
                       color="#1D3448"
                       fontFamily="'Open Sans', sans-serif"
                     >
                       {t('selectTime')}
                     </Text>
-                    <Text fontSize="sm" color="#6B7280" fontFamily="'Open Sans', sans-serif">
+                    <Text
+                      fontSize={{ base: 'xs', lg: 'sm' }}
+                      color="#6B7280"
+                      fontFamily="'Open Sans', sans-serif"
+                    >
                       {t('allTimesInTimezone', { timezone: 'EST' })}
                     </Text>
                   </Box>
@@ -269,9 +281,10 @@ export default function ScheduleCallPage() {
                         fontWeight="400"
                         fontSize="sm"
                         fontFamily="'Open Sans', sans-serif"
-                        px={6}
+                        px={{ base: 4, lg: 6 }}
                         py={5}
                         borderRadius="6px"
+                        minW={{ base: 'calc(33% - 8px)', lg: 'auto' }}
                         _hover={{
                           borderColor: '#056067',
                         }}
@@ -284,7 +297,7 @@ export default function ScheduleCallPage() {
               )}
 
               {/* Action Buttons */}
-              <Flex justify="flex-end" mt={4}>
+              <Flex justify={{ base: 'stretch', lg: 'flex-end' }} mt={4}>
                 {selectedDate && selectedTimeBlockId ? (
                   <Button
                     bg="#056067"
@@ -295,6 +308,7 @@ export default function ScheduleCallPage() {
                     px={8}
                     py={6}
                     borderRadius="md"
+                    w={{ base: '100%', lg: 'auto' }}
                     _hover={{
                       bg: '#044d52',
                     }}
@@ -315,6 +329,7 @@ export default function ScheduleCallPage() {
                     px={8}
                     py={6}
                     borderRadius="md"
+                    w={{ base: '100%', lg: 'auto' }}
                     _hover={{
                       bg: '#822727',
                     }}

--- a/frontend/src/pages/participant/schedule/[matchId].tsx
+++ b/frontend/src/pages/participant/schedule/[matchId].tsx
@@ -7,8 +7,6 @@ import { participantMatchAPIClient } from '@/APIClients/participantMatchAPIClien
 import { FormStatus, UserRole } from '@/types/authTypes';
 import { Match, TimeBlock } from '@/types/matchTypes';
 import { useTranslations } from 'next-intl';
-import { useIsDesktop } from '@/hooks/useIsDesktop';
-
 interface GroupedTimeBlocks {
   [date: string]: TimeBlock[];
 }
@@ -17,7 +15,6 @@ export default function ScheduleCallPage() {
   const t = useTranslations('dashboard');
   const router = useRouter();
   const { matchId } = router.query;
-  const isDesktop = useIsDesktop();
 
   const [match, setMatch] = useState<Match | null>(null);
   const [loading, setLoading] = useState(true);

--- a/frontend/src/pages/volunteer/dashboard.tsx
+++ b/frontend/src/pages/volunteer/dashboard.tsx
@@ -114,7 +114,7 @@ const VolunteerDashboardPage: React.FC = () => {
             fontSize={{ base: '1.5rem', lg: '2.25rem' }}
             fontWeight={600}
             lineHeight={{ base: '120%', lg: '100%' }}
-            letterSpacing="-1.5%"
+            letterSpacing="-0.015em"
             color="#1D3448"
             fontFamily="'Open Sans', sans-serif"
             textAlign="left"

--- a/frontend/src/pages/volunteer/dashboard.tsx
+++ b/frontend/src/pages/volunteer/dashboard.tsx
@@ -111,9 +111,9 @@ const VolunteerDashboardPage: React.FC = () => {
       <FormStatusGuard allowedStatuses={[FormStatus.COMPLETED]}>
         <VolunteerDashboardLayout>
           <Heading
-            fontSize="2.25rem"
+            fontSize={{ base: '1.5rem', lg: '2.25rem' }}
             fontWeight={600}
-            lineHeight="100%"
+            lineHeight={{ base: '120%', lg: '100%' }}
             letterSpacing="-1.5%"
             color="#1D3448"
             fontFamily="'Open Sans', sans-serif"
@@ -126,11 +126,11 @@ const VolunteerDashboardPage: React.FC = () => {
           </Heading>
 
           <Text
-            fontSize="16px"
+            fontSize={{ base: '14px', lg: '16px' }}
             color="#6B7280"
             fontFamily="'Open Sans', sans-serif"
             textAlign="left"
-            mb={8}
+            mb={{ base: 4, lg: 8 }}
           >
             {matchedParticipants.length > 0
               ? t('pleaseScheduleCalls')

--- a/frontend/src/pages/volunteer/dashboard/scheduled-calls.tsx
+++ b/frontend/src/pages/volunteer/dashboard/scheduled-calls.tsx
@@ -104,9 +104,9 @@ const ScheduledCallsPage: React.FC = () => {
       <FormStatusGuard allowedStatuses={[FormStatus.COMPLETED]}>
         <VolunteerDashboardLayout>
           <Heading
-            fontSize="2.25rem"
+            fontSize={{ base: '1.5rem', lg: '2.25rem' }}
             fontWeight={600}
-            lineHeight="100%"
+            lineHeight={{ base: '120%', lg: '100%' }}
             letterSpacing="-1.5%"
             color="#1D3448"
             fontFamily="'Open Sans', sans-serif"
@@ -119,17 +119,17 @@ const ScheduledCallsPage: React.FC = () => {
           </Heading>
 
           <Text
-            fontSize="16px"
+            fontSize={{ base: '14px', lg: '16px' }}
             color="#6B7280"
             fontFamily="'Open Sans', sans-serif"
             textAlign="left"
-            mb={8}
+            mb={{ base: 4, lg: 8 }}
           >
             {scheduledCalls.length > 0 ? t('hereAreUpcomingCalls') : t('noScheduledCallsYet')}
           </Text>
 
           {scheduledCalls.length > 0 && (
-            <VStack gap={6} align="flex-start">
+            <VStack gap={6} align={{ base: 'stretch', lg: 'flex-start' }} w="100%">
               {scheduledCalls.map((call) => (
                 <ProfileCard
                   key={call.id}

--- a/frontend/src/pages/volunteer/dashboard/scheduled-calls.tsx
+++ b/frontend/src/pages/volunteer/dashboard/scheduled-calls.tsx
@@ -107,7 +107,7 @@ const ScheduledCallsPage: React.FC = () => {
             fontSize={{ base: '1.5rem', lg: '2.25rem' }}
             fontWeight={600}
             lineHeight={{ base: '120%', lg: '100%' }}
-            letterSpacing="-1.5%"
+            letterSpacing="-0.015em"
             color="#1D3448"
             fontFamily="'Open Sans', sans-serif"
             textAlign="left"
@@ -138,7 +138,7 @@ const ScheduledCallsPage: React.FC = () => {
                   showTimes={!!call.scheduledTime}
                   onViewContact={() => {
                     // Handle view contact action
-                    console.log('View contact for', call.name);
+                    // TODO: Implement view contact details for volunteer
                   }}
                 />
               ))}

--- a/frontend/src/pages/volunteer/edit-profile.tsx
+++ b/frontend/src/pages/volunteer/edit-profile.tsx
@@ -733,7 +733,7 @@ const EditProfile: React.FC = () => {
         fontWeight={600}
         color={COLORS.veniceBlue}
         fontFamily="'Open Sans', sans-serif"
-        letterSpacing="-1.5%"
+        letterSpacing="-0.015em"
         mb={6}
         textAlign="center"
       >
@@ -835,7 +835,7 @@ const EditProfile: React.FC = () => {
                 fontSize="2.25rem"
                 fontWeight={600}
                 lineHeight="100%"
-                letterSpacing="-1.5%"
+                letterSpacing="-0.015em"
                 color={COLORS.veniceBlue}
                 fontFamily="'Open Sans', sans-serif"
               >

--- a/frontend/src/pages/volunteer/edit-profile.tsx
+++ b/frontend/src/pages/volunteer/edit-profile.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import TimeScheduler from '@/components/dashboard/TimeScheduler';
 import type { TimeSlot } from '@/components/dashboard/types';
-import { Box, Heading, Text, VStack, HStack, Button } from '@chakra-ui/react';
+import { Box, Heading, Text, VStack, HStack, Button, Tabs } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
 import { BiArrowBack } from 'react-icons/bi';
 import PersonalDetails from '@/components/dashboard/PersonalDetails';
@@ -17,6 +17,7 @@ import {
 } from '@/APIClients/userDataAPIClient';
 import { extractTimezoneAbbreviation, getTimezoneDisplayName } from '@/utils/timezoneUtils';
 import { useTranslations } from 'next-intl';
+import { useIsDesktop } from '@/hooks/useIsDesktop';
 
 const EditProfile: React.FC = () => {
   const t = useTranslations('dashboard');
@@ -25,6 +26,8 @@ const EditProfile: React.FC = () => {
   const router = useRouter();
   const [loading, setLoading] = useState(true);
   const [savingAvailability, setSavingAvailability] = useState(false);
+  const isDesktop = useIsDesktop();
+  const [selectedMobileDay, setSelectedMobileDay] = useState<string>('Sunday');
 
   // Personal details state for profile
   const [personalDetails, setPersonalDetails] = useState({
@@ -413,7 +416,404 @@ const EditProfile: React.FC = () => {
     return null;
   }
 
-  return (
+  // Mobile day abbreviations for availability selector
+  const mobileDays = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
+  const dayFullNames: Record<string, string> = {
+    SUN: 'Sunday',
+    MON: 'Monday',
+    TUE: 'Tuesday',
+    WED: 'Wednesday',
+    THU: 'Thursday',
+    FRI: 'Friday',
+    SAT: 'Saturday',
+  };
+  const hours = Array.from({ length: 13 }, (_, i) => i + 8); // 8 AM to 8 PM
+
+  const formatMobileTime = (hour: number) => {
+    if (hour <= 11) {
+      return `${hour} AM`;
+    } else if (hour === 12) {
+      return `12 PM`;
+    } else {
+      return `${hour - 12} PM`;
+    }
+  };
+
+  const isTimeSlotSelectedForDay = (day: string, hour: number) => {
+    const timeStr = `${hour}:00 - ${hour + 1}:00`;
+    return profileTimeSlots.some((slot) => slot.day === day && slot.time === timeStr);
+  };
+
+  const handleMobileTimeSlotToggle = (day: string, hour: number) => {
+    if (!isEditingAvailability) return;
+    const timeStr = `${hour}:00 - ${hour + 1}:00`;
+    const existingSlotIndex = profileTimeSlots.findIndex(
+      (slot) => slot.day === day && slot.time === timeStr,
+    );
+
+    let newSlots: TimeSlot[];
+    if (existingSlotIndex >= 0) {
+      newSlots = profileTimeSlots.filter((_, index) => index !== existingSlotIndex);
+    } else {
+      newSlots = [...profileTimeSlots, { day, time: timeStr, selected: true }];
+    }
+
+    setProfileTimeSlots(newSlots);
+    if (handleTimeSlotsChange) {
+      handleTimeSlotsChange(newSlots);
+    }
+  };
+
+  // Render personal details content
+  const renderPersonalDetails = () => (
+    <PersonalDetails
+      personalDetails={personalDetails}
+      setPersonalDetails={setPersonalDetails}
+      lovedOneDetails={lovedOneDetails}
+      setLovedOneDetails={setLovedOneDetails}
+      onSave={handleSavePersonalDetail}
+    />
+  );
+
+  // Render blood cancer experience content
+  const renderHistory = () => (
+    <BloodCancerExperience
+      cancerExperience={cancerExperience}
+      setCancerExperience={setCancerExperience}
+      lovedOneCancerExperience={lovedOneCancerExperience}
+      setLovedOneCancerExperience={setLovedOneCancerExperience}
+      onEditTreatments={handleSaveTreatments}
+      onEditExperiences={handleSaveExperiences}
+      onEditLovedOneTreatments={handleSaveLovedOneTreatments}
+      onEditLovedOneExperiences={handleSaveLovedOneExperiences}
+    />
+  );
+
+  // Render availability content for desktop
+  const renderAvailabilityDesktop = () => (
+    <Box bg="white" p={0} mt="116px" w="100%" h="1100px" pb={12}>
+      <HStack justify="space-between" align="center" mb={0}>
+        <Heading
+          w="519px"
+          h="40px"
+          fontSize="1.625rem"
+          fontWeight={600}
+          lineHeight="40px"
+          letterSpacing="0%"
+          color="#1D3448"
+          fontFamily="'Open Sans', sans-serif"
+          mb="8px"
+        >
+          {t('yourAvailabilityHeading')}
+        </Heading>
+        {!isEditingAvailability ? (
+          <ActionButton onClick={handleEditAvailability}>{t('edit')}</ActionButton>
+        ) : (
+          <HStack gap={3}>
+            <Button
+              bg="#B91C1C"
+              color="white"
+              px={4}
+              py={2}
+              borderRadius="6px"
+              fontFamily="'Open Sans', sans-serif"
+              fontWeight={600}
+              fontSize="0.875rem"
+              _hover={{ bg: '#991B1B' }}
+              _active={{ bg: '#7F1D1D' }}
+              onClick={handleClearAvailability}
+            >
+              {t('clearAvailability')}
+            </Button>
+            <Button
+              bg="#6B7280"
+              color="white"
+              px={4}
+              py={2}
+              borderRadius="6px"
+              fontFamily="'Open Sans', sans-serif"
+              fontWeight={600}
+              fontSize="0.875rem"
+              _hover={{ bg: '#4B5563' }}
+              _active={{ bg: '#374151' }}
+              onClick={handleCancelEdit}
+            >
+              {t('cancel')}
+            </Button>
+            <Button
+              bg="#056067"
+              color="white"
+              px={4}
+              py={2}
+              borderRadius="6px"
+              fontFamily="'Open Sans', sans-serif"
+              fontWeight={600}
+              fontSize="0.875rem"
+              _hover={{ bg: '#044d52' }}
+              _active={{ bg: '#033e42' }}
+              onClick={handleSaveAvailability}
+              disabled={savingAvailability}
+            >
+              {savingAvailability ? t('saving') : t('save')}
+            </Button>
+          </HStack>
+        )}
+      </HStack>
+
+      <Text
+        fontSize="1rem"
+        fontWeight={400}
+        lineHeight="100%"
+        letterSpacing="0%"
+        color="#495D6C"
+        mb={4}
+        mt={0}
+        fontFamily="'Open Sans', sans-serif"
+      >
+        {t('weRequire2Hours')}
+      </Text>
+
+      <Box h="900px" w="100%" mr={0}>
+        <TimeScheduler
+          showAvailability={true}
+          onTimeSlotsChange={handleTimeSlotsChange}
+          initialTimeSlots={profileTimeSlots}
+          readOnly={!isEditingAvailability}
+        />
+      </Box>
+    </Box>
+  );
+
+  // Render mobile availability with day selector and vertical time list
+  const renderAvailabilityMobile = () => (
+    <VStack align="stretch" gap={4}>
+      <Text fontSize="16px" fontWeight={600} color="#1D3448" fontFamily="'Open Sans', sans-serif">
+        {t('yourAvailabilityHeading')}
+      </Text>
+      <Text fontSize="14px" fontWeight={400} color="#495D6C" fontFamily="'Open Sans', sans-serif">
+        {t('weRequire2Hours')}
+      </Text>
+
+      {/* Day selector pills */}
+      <HStack gap={2} overflowX="auto" pb={2}>
+        {mobileDays.map((day) => (
+          <Box
+            key={day}
+            px={3}
+            py={2}
+            borderRadius="full"
+            bg={selectedMobileDay === dayFullNames[day] ? '#1D3448' : 'white'}
+            color={selectedMobileDay === dayFullNames[day] ? 'white' : '#1D3448'}
+            border="1px solid"
+            borderColor={selectedMobileDay === dayFullNames[day] ? '#1D3448' : '#E5E7EB'}
+            cursor="pointer"
+            onClick={() => setSelectedMobileDay(dayFullNames[day])}
+            fontFamily="'Open Sans', sans-serif"
+            fontSize="14px"
+            fontWeight={500}
+            flexShrink={0}
+          >
+            {day}
+          </Box>
+        ))}
+      </HStack>
+
+      {/* Vertical time slots list */}
+      <VStack align="stretch" gap={0}>
+        {hours.map((hour) => {
+          const isSelected = isTimeSlotSelectedForDay(selectedMobileDay, hour);
+          return (
+            <Box
+              key={hour}
+              py={3}
+              px={4}
+              borderBottom="1px solid"
+              borderColor="#E5E7EB"
+              display="flex"
+              alignItems="center"
+              justifyContent="space-between"
+              cursor={isEditingAvailability ? 'pointer' : 'default'}
+              onClick={() => handleMobileTimeSlotToggle(selectedMobileDay, hour)}
+              bg={isSelected ? 'rgba(255, 187, 138, 0.2)' : 'white'}
+            >
+              <Text
+                fontSize="14px"
+                fontWeight={400}
+                color="#1D3448"
+                fontFamily="'Open Sans', sans-serif"
+              >
+                {formatMobileTime(hour)}
+              </Text>
+              {isSelected && (
+                <Box
+                  bg="rgba(255, 187, 138, 0.5)"
+                  color="#1D3448"
+                  px={3}
+                  py={1}
+                  borderRadius="4px"
+                  fontSize="12px"
+                  fontWeight={500}
+                  fontFamily="'Open Sans', sans-serif"
+                >
+                  {formatMobileTime(hour)} - {formatMobileTime(hour + 1)}
+                </Box>
+              )}
+            </Box>
+          );
+        })}
+      </VStack>
+
+      {/* Action buttons */}
+      {!isEditingAvailability ? (
+        <Button
+          bg="#056067"
+          color="white"
+          w="100%"
+          py={6}
+          borderRadius="8px"
+          fontFamily="'Open Sans', sans-serif"
+          fontWeight={600}
+          fontSize="16px"
+          _hover={{ bg: '#044d52' }}
+          _active={{ bg: '#033e42' }}
+          onClick={handleEditAvailability}
+        >
+          {t('editAvailability')}
+        </Button>
+      ) : (
+        <HStack gap={3}>
+          <Button
+            flex={1}
+            bg="#B91C1C"
+            color="white"
+            py={6}
+            borderRadius="8px"
+            fontFamily="'Open Sans', sans-serif"
+            fontWeight={600}
+            fontSize="14px"
+            _hover={{ bg: '#991B1B' }}
+            _active={{ bg: '#7F1D1D' }}
+            onClick={handleClearAvailability}
+          >
+            {t('clearAvailability')}
+          </Button>
+          <Button
+            flex={1}
+            bg="#056067"
+            color="white"
+            py={6}
+            borderRadius="8px"
+            fontFamily="'Open Sans', sans-serif"
+            fontWeight={600}
+            fontSize="14px"
+            _hover={{ bg: '#044d52' }}
+            _active={{ bg: '#033e42' }}
+            onClick={handleSaveAvailability}
+            disabled={savingAvailability}
+          >
+            {savingAvailability ? t('saving') : t('saveChanges')}
+          </Button>
+        </HStack>
+      )}
+    </VStack>
+  );
+
+  // Mobile layout with tabs
+  const renderMobileLayout = () => (
+    <Box minH="100vh" bg="white" px={4} py={6}>
+      <HStack gap={2} align="center" cursor="pointer" onClick={handleBack} mb={4}>
+        <BiArrowBack color={COLORS.veniceBlue} />
+        <Text fontSize="sm" color={COLORS.fieldGray} fontFamily="'Open Sans', sans-serif">
+          {t('back')}
+        </Text>
+      </HStack>
+
+      <Heading
+        fontSize="24px"
+        fontWeight={600}
+        color={COLORS.veniceBlue}
+        fontFamily="'Open Sans', sans-serif"
+        letterSpacing="-1.5%"
+        mb={6}
+        textAlign="center"
+      >
+        {t('editProfile')}
+      </Heading>
+
+      <Tabs.Root defaultValue="personal" variant="line">
+        <Tabs.List mb={6} borderBottomWidth="1px" borderColor="#E5E7EB" gap={0}>
+          <Tabs.Trigger
+            value="personal"
+            flex={1}
+            fontSize="14px"
+            fontWeight={400}
+            fontFamily="'Open Sans', sans-serif"
+            color="#6B7280"
+            pb={3}
+            _selected={{
+              color: '#1D3448',
+              fontWeight: 600,
+              borderBottomWidth: '2px',
+              borderColor: '#1D3448',
+            }}
+          >
+            {t('personalDetails')}
+          </Tabs.Trigger>
+          <Tabs.Trigger
+            value="history"
+            flex={1}
+            fontSize="14px"
+            fontWeight={400}
+            fontFamily="'Open Sans', sans-serif"
+            color="#6B7280"
+            pb={3}
+            _selected={{
+              color: '#1D3448',
+              fontWeight: 600,
+              borderBottomWidth: '2px',
+              borderColor: '#1D3448',
+            }}
+          >
+            {t('history')}
+          </Tabs.Trigger>
+          <Tabs.Trigger
+            value="availability"
+            flex={1}
+            fontSize="14px"
+            fontWeight={400}
+            fontFamily="'Open Sans', sans-serif"
+            color="#6B7280"
+            pb={3}
+            _selected={{
+              color: '#1D3448',
+              fontWeight: 600,
+              borderBottomWidth: '2px',
+              borderColor: '#1D3448',
+            }}
+          >
+            {t('availability')}
+          </Tabs.Trigger>
+        </Tabs.List>
+
+        <Tabs.Content value="personal">
+          <VStack gap={0} align="stretch">
+            {renderPersonalDetails()}
+          </VStack>
+        </Tabs.Content>
+
+        <Tabs.Content value="history">
+          <VStack gap={0} align="stretch">
+            {renderHistory()}
+          </VStack>
+        </Tabs.Content>
+
+        <Tabs.Content value="availability">{renderAvailabilityMobile()}</Tabs.Content>
+      </Tabs.Root>
+    </Box>
+  );
+
+  // Desktop layout (original)
+  const renderDesktopLayout = () => (
     <Box minH="100vh" bg="white" py={6} display="flex" justifyContent="center">
       <Box minH="2409px" overflow="auto" w="85%">
         <VStack gap={6} align="stretch" p={6}>
@@ -444,114 +844,9 @@ const EditProfile: React.FC = () => {
 
               <Box mt="48px">
                 <VStack gap={0} align="stretch">
-                  <PersonalDetails
-                    personalDetails={personalDetails}
-                    setPersonalDetails={setPersonalDetails}
-                    lovedOneDetails={lovedOneDetails}
-                    setLovedOneDetails={setLovedOneDetails}
-                    onSave={handleSavePersonalDetail}
-                  />
-                  <BloodCancerExperience
-                    cancerExperience={cancerExperience}
-                    setCancerExperience={setCancerExperience}
-                    lovedOneCancerExperience={lovedOneCancerExperience}
-                    setLovedOneCancerExperience={setLovedOneCancerExperience}
-                    onEditTreatments={handleSaveTreatments}
-                    onEditExperiences={handleSaveExperiences}
-                    onEditLovedOneTreatments={handleSaveLovedOneTreatments}
-                    onEditLovedOneExperiences={handleSaveLovedOneExperiences}
-                  />
-                  <Box bg="white" p={0} mt="116px" w="100%" h="1100px" pb={12}>
-                    <HStack justify="space-between" align="center" mb={0}>
-                      <Heading
-                        w="519px"
-                        h="40px"
-                        fontSize="1.625rem"
-                        fontWeight={600}
-                        lineHeight="40px"
-                        letterSpacing="0%"
-                        color="#1D3448"
-                        fontFamily="'Open Sans', sans-serif"
-                        mb="8px"
-                      >
-                        {t('yourAvailabilityHeading')}
-                      </Heading>
-                      {!isEditingAvailability ? (
-                        <ActionButton onClick={handleEditAvailability}>{t('edit')}</ActionButton>
-                      ) : (
-                        <HStack gap={3}>
-                          <Button
-                            bg="#B91C1C"
-                            color="white"
-                            px={4}
-                            py={2}
-                            borderRadius="6px"
-                            fontFamily="'Open Sans', sans-serif"
-                            fontWeight={600}
-                            fontSize="0.875rem"
-                            _hover={{ bg: '#991B1B' }}
-                            _active={{ bg: '#7F1D1D' }}
-                            onClick={handleClearAvailability}
-                          >
-                            {t('clearAvailability')}
-                          </Button>
-                          <Button
-                            bg="#6B7280"
-                            color="white"
-                            px={4}
-                            py={2}
-                            borderRadius="6px"
-                            fontFamily="'Open Sans', sans-serif"
-                            fontWeight={600}
-                            fontSize="0.875rem"
-                            _hover={{ bg: '#4B5563' }}
-                            _active={{ bg: '#374151' }}
-                            onClick={handleCancelEdit}
-                          >
-                            {t('cancel')}
-                          </Button>
-                          <Button
-                            bg="#056067"
-                            color="white"
-                            px={4}
-                            py={2}
-                            borderRadius="6px"
-                            fontFamily="'Open Sans', sans-serif"
-                            fontWeight={600}
-                            fontSize="0.875rem"
-                            _hover={{ bg: '#044d52' }}
-                            _active={{ bg: '#033e42' }}
-                            onClick={handleSaveAvailability}
-                            disabled={savingAvailability}
-                          >
-                            {savingAvailability ? t('saving') : t('save')}
-                          </Button>
-                        </HStack>
-                      )}
-                    </HStack>
-
-                    <Text
-                      fontSize="1rem"
-                      fontWeight={400}
-                      lineHeight="100%"
-                      letterSpacing="0%"
-                      color="#495D6C"
-                      mb={4}
-                      mt={0}
-                      fontFamily="'Open Sans', sans-serif"
-                    >
-                      {t('weRequire2Hours')}
-                    </Text>
-
-                    <Box h="900px" w="100%" mr={0}>
-                      <TimeScheduler
-                        showAvailability={true}
-                        onTimeSlotsChange={handleTimeSlotsChange}
-                        initialTimeSlots={profileTimeSlots}
-                        readOnly={!isEditingAvailability}
-                      />
-                    </Box>
-                  </Box>
+                  {renderPersonalDetails()}
+                  {renderHistory()}
+                  {renderAvailabilityDesktop()}
                 </VStack>
               </Box>
             </VStack>
@@ -560,6 +855,8 @@ const EditProfile: React.FC = () => {
       </Box>
     </Box>
   );
+
+  return isDesktop ? renderDesktopLayout() : renderMobileLayout();
 };
 
 export default EditProfile;


### PR DESCRIPTION
## Summary
- Add MobileHeader component with hamburger menu, logo, and user avatar
- Add MobileDrawer component for mobile slide-out navigation

## What's Done
- Created reusable mobile navigation components
- useIsDesktop hook already exists for responsive logic

## What's Left
- [ ] Integrate MobileHeader/MobileDrawer into VolunteerDashboardLayout
- [ ] Integrate MobileHeader/MobileDrawer into ParticipantDashboardLayout  
- [ ] Add responsive padding/typography to dashboard pages
- [ ] Update schedule call pages for mobile
- [ ] Update edit profile modals with tabs for mobile
- [ ] Update contact form for mobile responsiveness

## Design Reference
See Dash Mobile Styles/ folder for Figma screenshots