### PR TITLE
Fix email subject lines showing "there" and add missing notifications

### DIFF
--- a/backend/app/routes/intake.py
+++ b/backend/app/routes/intake.py
@@ -14,6 +14,7 @@ from app.schemas.user import UserRole
 from app.services.implementations.form_processor import FormProcessor
 from app.utilities.db_utils import get_db
 from app.utilities.ses_email_service import SESEmailService
+from app.utilities.user_name import resolve_user_first_name
 
 # ===== Schemas =====
 
@@ -277,7 +278,7 @@ async def create_form_submission(
                 # Get language (enum values are already "en" or "fr")
                 language = target_user.language.value if target_user.language else "en"
 
-                first_name = target_user.first_name if target_user.first_name else None
+                first_name = resolve_user_first_name(target_user)
                 ses_service.send_intake_form_confirmation_email(
                     to_email=target_user.email, first_name=first_name, language=language
                 )

--- a/backend/app/routes/match.py
+++ b/backend/app/routes/match.py
@@ -236,7 +236,9 @@ async def accept_requested_times(
     """Volunteer accepts one of the participant's requested time blocks."""
     try:
         acting_volunteer_id = await _resolve_acting_volunteer_id(request, user_service)
-        return await match_service.volunteer_accept_requested_times(match_id, payload.time_block_id, acting_volunteer_id)
+        return await match_service.volunteer_accept_requested_times(
+            match_id, payload.time_block_id, acting_volunteer_id
+        )
     except HTTPException as http_ex:
         raise http_ex
     except Exception as e:

--- a/backend/app/routes/ranking.py
+++ b/backend/app/routes/ranking.py
@@ -15,6 +15,7 @@ from app.utilities.db_utils import get_db
 from app.utilities.service_utils import get_user_service
 from app.utilities.ses_email_service import SESEmailService
 from app.utilities.task_utils import create_volunteer_app_review_task
+from app.utilities.user_name import resolve_user_first_name
 
 
 class StaticQualityOption(BaseModel):
@@ -97,7 +98,7 @@ async def put_ranking_preferences(
                 ses_service = SESEmailService()
                 ses_service.send_ranking_form_confirmation_email(
                     to_email=user.email,
-                    first_name=user.first_name,
+                    first_name=resolve_user_first_name(user),
                     language=language,
                 )
         except Exception:

--- a/backend/app/routes/volunteer_data.py
+++ b/backend/app/routes/volunteer_data.py
@@ -19,6 +19,7 @@ from app.utilities.db_utils import get_db
 from app.utilities.service_utils import get_user_service, get_volunteer_data_service
 from app.utilities.ses_email_service import SESEmailService
 from app.utilities.task_utils import create_volunteer_app_review_task
+from app.utilities.user_name import resolve_user_first_name
 
 router = APIRouter(
     prefix="/volunteer-data",
@@ -66,7 +67,7 @@ async def submit_volunteer_data(
                 ses_service = SESEmailService()
                 ses_service.send_secondary_app_confirmation_email(
                     to_email=user.email,
-                    first_name=user.first_name,
+                    first_name=resolve_user_first_name(user),
                     language=language,
                 )
         except Exception:

--- a/backend/app/services/implementations/auth_service.py
+++ b/backend/app/services/implementations/auth_service.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException
 
 from app.utilities.constants import LOGGER_NAME
 from app.utilities.ses_email_service import SESEmailService
+from app.utilities.user_name import resolve_user_first_name
 
 from ...interfaces.auth_service import IAuthService
 from ...schemas.auth import AuthResponse, Token
@@ -57,8 +58,7 @@ class AuthService(IAuthService):
                 try:
                     user = self.user_service.get_user_by_email(email)
                     if user:
-                        if user.first_name and user.first_name.strip():
-                            first_name = user.first_name.strip()
+                        first_name = resolve_user_first_name(user)
                         # Get language from user (enum values are already "en" or "fr")
                         if user.language:
                             language = user.language.value
@@ -127,8 +127,9 @@ class AuthService(IAuthService):
                 if not first_name:
                     try:
                         user = self.user_service.get_user_by_email(email)
-                        if user and user.first_name and user.first_name.strip():
-                            first_name = user.first_name.strip()
+                        resolved_name = resolve_user_first_name(user) if user else None
+                        if resolved_name:
+                            first_name = resolved_name
                             self.logger.info(f"Found first name '{first_name}' from database for user {email}")
                         else:
                             self.logger.debug(f"No first name found in database for user {email}")

--- a/backend/app/services/implementations/form_processor.py
+++ b/backend/app/services/implementations/form_processor.py
@@ -30,6 +30,7 @@ from app.services.implementations.intake_form_processor import IntakeFormProcess
 from app.services.implementations.volunteer_data_service import VolunteerDataService
 from app.utilities.constants import LOGGER_NAME
 from app.utilities.ses_email_service import SESEmailService
+from app.utilities.user_name import resolve_user_first_name
 
 
 class FormProcessor:
@@ -100,7 +101,7 @@ class FormProcessor:
                 ses_service = SESEmailService()
                 ses_service.send_intake_approved_participant_email(
                     to_email=user.email,
-                    first_name=user.first_name,
+                    first_name=resolve_user_first_name(user),
                     language=language,
                 )
             except Exception as e:
@@ -112,7 +113,7 @@ class FormProcessor:
                 ses_service = SESEmailService()
                 ses_service.send_intake_approved_volunteer_email(
                     to_email=user.email,
-                    first_name=user.first_name,
+                    first_name=resolve_user_first_name(user),
                     language=language,
                 )
             except Exception as e:
@@ -178,7 +179,7 @@ class FormProcessor:
                 ses_service = SESEmailService()
                 ses_service.send_ranking_approved_email(
                     to_email=user.email,
-                    first_name=user.first_name,
+                    first_name=resolve_user_first_name(user),
                     language=language,
                 )
             except Exception as e:
@@ -202,7 +203,7 @@ class FormProcessor:
                 ses_service = SESEmailService()
                 ses_service.send_secondary_app_approved_email(
                     to_email=user.email,
-                    first_name=user.first_name,
+                    first_name=resolve_user_first_name(user),
                     language=language,
                 )
             except Exception as e:

--- a/backend/app/services/implementations/match_service.py
+++ b/backend/app/services/implementations/match_service.py
@@ -27,6 +27,7 @@ from app.schemas.time_block import TimeBlockEntity, TimeRange
 from app.schemas.user import UserRole
 from app.utilities.ses_email_service import SESEmailService
 from app.utilities.timezone_utils import get_timezone_from_abbreviation
+from app.utilities.user_name import resolve_user_first_name
 
 SCHEDULE_CLEANUP_STATUSES = {
     "pending",
@@ -106,7 +107,7 @@ class MatchService:
                         # Get volunteer's language (enum values are already "en" or "fr")
                         language = volunteer.language.value if volunteer.language else "en"
 
-                        first_name = volunteer.first_name if volunteer.first_name else None
+                        first_name = resolve_user_first_name(volunteer)
                         matches_url = f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/volunteer/dashboard"
 
                         ses_service.send_matches_available_email(
@@ -342,7 +343,7 @@ class MatchService:
                             date=participant_date,
                             time=participant_time_str,
                             timezone=participant_tz_abbr,
-                            first_name=participant.first_name,
+                            first_name=resolve_user_first_name(participant),
                             scheduled_calls_url=f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/participant/dashboard",
                             language=participant_language,
                         )
@@ -357,7 +358,7 @@ class MatchService:
                             date=volunteer_date,
                             time=volunteer_time_str,
                             timezone=volunteer_tz_abbr,
-                            first_name=volunteer.first_name,
+                            first_name=resolve_user_first_name(volunteer),
                             scheduled_calls_url=f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/volunteer/dashboard",
                             language=volunteer_language,
                         )
@@ -446,7 +447,7 @@ class MatchService:
                     ses_service.send_participant_requested_new_times_email(
                         to_email=volunteer.email,
                         participant_name=participant_name,
-                        first_name=volunteer.first_name,
+                        first_name=resolve_user_first_name(volunteer),
                         matches_url=f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/volunteer/dashboard",
                         language=volunteer_language,
                     )
@@ -532,7 +533,7 @@ class MatchService:
                             date=volunteer_date,
                             time=volunteer_time_str,
                             timezone=volunteer_tz_abbr,
-                            first_name=volunteer.first_name,
+                            first_name=resolve_user_first_name(volunteer),
                             dashboard_url=f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/volunteer/dashboard",
                             language=volunteer_language,
                         )
@@ -622,7 +623,7 @@ class MatchService:
                             date=participant_date,
                             time=participant_time_str,
                             timezone=participant_tz_abbr,
-                            first_name=participant.first_name,
+                            first_name=resolve_user_first_name(participant),
                             request_matches_url=f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/participant/dashboard",
                             language=participant_language,
                         )
@@ -830,7 +831,7 @@ class MatchService:
                     # Get participant's language (enum values are already "en" or "fr")
                     language = participant.language.value if participant.language else "en"
 
-                    first_name = participant.first_name if participant.first_name else None
+                    first_name = resolve_user_first_name(participant)
                     matches_url = f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/participant/dashboard"
 
                     ses_service = SESEmailService()
@@ -903,6 +904,82 @@ class MatchService:
             self.db.flush()
             self.db.commit()
             self.db.refresh(match)
+
+            # Send confirmation emails for accepted requested times
+            try:
+                participant = match.participant
+                volunteer = match.volunteer
+
+                if participant and volunteer and match.confirmed_time:
+                    ses_service = SESEmailService()
+                    confirmed_time_utc = match.confirmed_time.start_time
+
+                    # Get participant's timezone and language
+                    participant_tz = ZoneInfo("America/Toronto")  # Default to EST
+                    if participant.user_data and participant.user_data.timezone:
+                        tz_result = get_timezone_from_abbreviation(participant.user_data.timezone)
+                        if tz_result:
+                            participant_tz = tz_result
+                    participant_language = participant.language.value if participant.language else "en"
+
+                    # Get volunteer's timezone and language
+                    volunteer_tz = ZoneInfo("America/Toronto")  # Default to EST
+                    if volunteer.user_data and volunteer.user_data.timezone:
+                        tz_result = get_timezone_from_abbreviation(volunteer.user_data.timezone)
+                        if tz_result:
+                            volunteer_tz = tz_result
+                    volunteer_language = volunteer.language.value if volunteer.language else "en"
+
+                    # Convert time to participant's timezone
+                    participant_time = confirmed_time_utc.astimezone(participant_tz)
+                    participant_date = participant_time.strftime("%B %d, %Y")
+                    participant_time_str = participant_time.strftime("%I:%M %p")
+                    participant_tz_abbr = participant_time.strftime("%Z")
+
+                    # Convert time to volunteer's timezone
+                    volunteer_time = confirmed_time_utc.astimezone(volunteer_tz)
+                    volunteer_date = volunteer_time.strftime("%B %d, %Y")
+                    volunteer_time_str = volunteer_time.strftime("%I:%M %p")
+                    volunteer_tz_abbr = volunteer_time.strftime("%Z")
+
+                    # Send participant notification (volunteer accepted requested time)
+                    if participant.email:
+                        volunteer_name = (
+                            f"{volunteer.first_name} {volunteer.last_name}"
+                            if volunteer.first_name and volunteer.last_name
+                            else volunteer.first_name or "Your volunteer"
+                        )
+                        ses_service.send_volunteer_accepted_new_times_email(
+                            to_email=participant.email,
+                            volunteer_name=volunteer_name,
+                            date=participant_date,
+                            time=participant_time_str,
+                            timezone=participant_tz_abbr,
+                            first_name=resolve_user_first_name(participant),
+                            scheduled_calls_url=f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/participant/dashboard",
+                            language=participant_language,
+                        )
+
+                    # Send volunteer confirmation (call is now scheduled)
+                    if volunteer.email:
+                        participant_name = (
+                            f"{participant.first_name} {participant.last_name}"
+                            if participant.first_name and participant.last_name
+                            else participant.first_name or "Your participant"
+                        )
+                        ses_service.send_call_scheduled_email(
+                            to_email=volunteer.email,
+                            match_name=participant_name,
+                            date=volunteer_date,
+                            time=volunteer_time_str,
+                            timezone=volunteer_tz_abbr,
+                            first_name=resolve_user_first_name(volunteer),
+                            scheduled_calls_url=f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/volunteer/dashboard",
+                            language=volunteer_language,
+                        )
+            except Exception as e:
+                # Log error but don't fail the acceptance
+                self.logger.error(f"Failed to send acceptance confirmation emails for match {match_id}: {e}")
 
             return self._build_match_detail_for_volunteer(match)
         except HTTPException:

--- a/backend/app/services/implementations/match_service.py
+++ b/backend/app/services/implementations/match_service.py
@@ -1101,8 +1101,7 @@ class MatchService:
         match_status_name = match.match_status.name if match.match_status else ""
 
         suggested_blocks = [
-            TimeBlockEntity(id=tb.id, start_time=tb.start_time)
-            for tb in (match.suggested_time_blocks or [])
+            TimeBlockEntity(id=tb.id, start_time=tb.start_time) for tb in (match.suggested_time_blocks or [])
         ]
 
         chosen_block = None

--- a/backend/app/utilities/ses/ses_templates.json
+++ b/backend/app/utilities/ses/ses_templates.json
@@ -7,13 +7,13 @@
   },
   {
     "HtmlPart": "app/utilities/ses/template_files/compiled/email_verification_en.html",
-    "SubjectPart": "{{first_name}}, confirm your email - First Connection Peer Support Program",
+    "SubjectPart": "{{subject_prefix}}{{subject_first_word}} your email - First Connection Peer Support Program",
     "TemplateName": "EmailVerificationEn",
     "TextPart": "app/utilities/ses/template_files/text/email_verification_en.txt"
   },
   {
     "HtmlPart": "app/utilities/ses/template_files/compiled/email_verification_fr.html",
-    "SubjectPart": "{{first_name}}, confirmation de l'adresse courriel – Programme de soutien par les pairs Premier contact",
+    "SubjectPart": "{{subject_prefix}}{{subject_first_word}} de l'adresse courriel – Programme de soutien par les pairs Premier contact",
     "TemplateName": "EmailVerificationFr",
     "TextPart": "app/utilities/ses/template_files/text/email_verification_fr.txt"
   },
@@ -43,13 +43,13 @@
   },
   {
     "HtmlPart": "app/utilities/ses/template_files/compiled/matches_available_en.html",
-    "SubjectPart": "{{first_name}}, you have new matches - First Connection Peer Support Program",
+    "SubjectPart": "{{subject_prefix}}{{subject_first_word}} have new matches - First Connection Peer Support Program",
     "TemplateName": "MatchesAvailableEn",
     "TextPart": "app/utilities/ses/template_files/text/matches_available_en.txt"
   },
   {
     "HtmlPart": "app/utilities/ses/template_files/compiled/matches_available_fr.html",
-    "SubjectPart": "{{first_name}}, nouveaux jumelages – Programme de soutien par les pairs Premier contact",
+    "SubjectPart": "{{subject_prefix}}{{subject_first_word}} jumelages – Programme de soutien par les pairs Premier contact",
     "TemplateName": "MatchesAvailableFr",
     "TextPart": "app/utilities/ses/template_files/text/matches_available_fr.txt"
   },
@@ -115,25 +115,25 @@
   },
   {
     "HtmlPart": "app/utilities/ses/template_files/compiled/intake_approved_participant_en.html",
-    "SubjectPart": "{{first_name}}, your matching preferences form is ready - First Connection Peer Support Program",
+    "SubjectPart": "{{subject_prefix}}{{subject_first_word}} matching preferences form is ready - First Connection Peer Support Program",
     "TemplateName": "IntakeApprovedParticipantEn",
     "TextPart": "app/utilities/ses/template_files/text/intake_approved_participant_en.txt"
   },
   {
     "HtmlPart": "app/utilities/ses/template_files/compiled/intake_approved_participant_fr.html",
-    "SubjectPart": "{{first_name}}, votre formulaire de préférences de jumelage est prêt – Programme de soutien par les pairs Premier contact",
+    "SubjectPart": "{{subject_prefix}}{{subject_first_word}} formulaire de préférences de jumelage est prêt – Programme de soutien par les pairs Premier contact",
     "TemplateName": "IntakeApprovedParticipantFr",
     "TextPart": "app/utilities/ses/template_files/text/intake_approved_participant_fr.txt"
   },
   {
     "HtmlPart": "app/utilities/ses/template_files/compiled/intake_approved_volunteer_en.html",
-    "SubjectPart": "{{first_name}}, your secondary application is ready - First Connection Peer Support Program",
+    "SubjectPart": "{{subject_prefix}}{{subject_first_word}} secondary application is ready - First Connection Peer Support Program",
     "TemplateName": "IntakeApprovedVolunteerEn",
     "TextPart": "app/utilities/ses/template_files/text/intake_approved_volunteer_en.txt"
   },
   {
     "HtmlPart": "app/utilities/ses/template_files/compiled/intake_approved_volunteer_fr.html",
-    "SubjectPart": "{{first_name}}, votre demande complémentaire est prête – Programme de soutien par les pairs Premier contact",
+    "SubjectPart": "{{subject_prefix}}{{subject_first_word}} demande complémentaire est prête – Programme de soutien par les pairs Premier contact",
     "TemplateName": "IntakeApprovedVolunteerFr",
     "TextPart": "app/utilities/ses/template_files/text/intake_approved_volunteer_fr.txt"
   },
@@ -151,13 +151,13 @@
   },
   {
     "HtmlPart": "app/utilities/ses/template_files/compiled/ranking_approved_en.html",
-    "SubjectPart": "{{first_name}}, you're ready for matching - First Connection Peer Support Program",
+    "SubjectPart": "{{subject_prefix}}{{subject_first_word}} ready for matching - First Connection Peer Support Program",
     "TemplateName": "RankingApprovedEn",
     "TextPart": "app/utilities/ses/template_files/text/ranking_approved_en.txt"
   },
   {
     "HtmlPart": "app/utilities/ses/template_files/compiled/ranking_approved_fr.html",
-    "SubjectPart": "{{first_name}}, vous êtes prêt(e) pour le jumelage – Programme de soutien par les pairs Premier contact",
+    "SubjectPart": "{{subject_prefix}}{{subject_first_word}} êtes prêt(e) pour le jumelage – Programme de soutien par les pairs Premier contact",
     "TemplateName": "RankingApprovedFr",
     "TextPart": "app/utilities/ses/template_files/text/ranking_approved_fr.txt"
   },
@@ -175,13 +175,13 @@
   },
   {
     "HtmlPart": "app/utilities/ses/template_files/compiled/secondary_app_approved_en.html",
-    "SubjectPart": "{{first_name}}, your volunteer profile is complete - First Connection Peer Support Program",
+    "SubjectPart": "{{subject_prefix}}{{subject_first_word}} volunteer profile is complete - First Connection Peer Support Program",
     "TemplateName": "SecondaryAppApprovedEn",
     "TextPart": "app/utilities/ses/template_files/text/secondary_app_approved_en.txt"
   },
   {
     "HtmlPart": "app/utilities/ses/template_files/compiled/secondary_app_approved_fr.html",
-    "SubjectPart": "{{first_name}}, votre profil de bénévole est complété – Programme de soutien par les pairs Premier contact",
+    "SubjectPart": "{{subject_prefix}}{{subject_first_word}} profil de bénévole est complété – Programme de soutien par les pairs Premier contact",
     "TemplateName": "SecondaryAppApprovedFr",
     "TextPart": "app/utilities/ses/template_files/text/secondary_app_approved_fr.txt"
   }

--- a/backend/app/utilities/ses_email_service.py
+++ b/backend/app/utilities/ses_email_service.py
@@ -39,6 +39,28 @@ class SESEmailService:
                 self.logger.error(f"Failed to initialize SES client: {str(e)}")
                 self.ses_client = None
 
+    def _normalize_first_name(self, first_name: str | None) -> str | None:
+        if not first_name:
+            return None
+        cleaned_name = first_name.strip()
+        return cleaned_name if cleaned_name else None
+
+    def _build_name_template_data(
+        self,
+        first_name: str | None,
+        subject_first_word: str | None = None,
+    ) -> Dict[str, str]:
+        normalized_name = self._normalize_first_name(first_name)
+        template_data = {
+            "first_name": normalized_name if normalized_name else "there",
+            "subject_prefix": f"{normalized_name}, " if normalized_name else "",
+        }
+        if subject_first_word:
+            word = subject_first_word.strip()
+            if word:
+                template_data["subject_first_word"] = word if normalized_name else word[0].upper() + word[1:]
+        return template_data
+
     def verify_email_address(self, email: str) -> bool:
         """
         Verify an email address in SES (for sandbox mode)
@@ -137,7 +159,13 @@ class SESEmailService:
         # Use appropriate source email based on language
         source_email = self.source_email_en if language == "en" else self.source_email_fr
 
-        template_data = {"verification_link": verification_link, "first_name": first_name if first_name else "there"}
+        template_data = {
+            **self._build_name_template_data(
+                first_name,
+                subject_first_word="confirm" if language == "en" else "confirmation",
+            ),
+            "verification_link": verification_link,
+        }
 
         return self.send_templated_email(to_email, template_name, template_data, source_email)
 
@@ -164,7 +192,10 @@ class SESEmailService:
         template_name = "PasswordResetEn" if language == "en" else "PasswordResetFr"
         source_email = self.source_email_en if language == "en" else self.source_email_fr
 
-        template_data = {"reset_link": reset_link, "first_name": first_name if first_name else "there"}
+        template_data = {
+            **self._build_name_template_data(first_name),
+            "reset_link": reset_link,
+        }
 
         return self.send_templated_email(to_email, template_name, template_data, source_email)
 
@@ -188,7 +219,7 @@ class SESEmailService:
         template_name = "IntakeFormConfirmationEn" if language == "en" else "IntakeFormConfirmationFr"
         source_email = self.source_email_en if language == "en" else self.source_email_fr
 
-        template_data = {"first_name": first_name if first_name else "there"}
+        template_data = self._build_name_template_data(first_name)
 
         return self.send_templated_email(to_email, template_name, template_data, source_email)
 
@@ -219,7 +250,13 @@ class SESEmailService:
         if not matches_url:
             matches_url = f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/participant/dashboard"
 
-        template_data = {"first_name": first_name if first_name else "there", "matches_url": matches_url}
+        template_data = {
+            **self._build_name_template_data(
+                first_name,
+                subject_first_word="you" if language == "en" else "nouveaux",
+            ),
+            "matches_url": matches_url,
+        }
 
         return self.send_templated_email(to_email, template_name, template_data, source_email)
 
@@ -263,7 +300,7 @@ class SESEmailService:
             scheduled_calls_url = f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/participant/dashboard"
 
         template_data = {
-            "first_name": first_name if first_name else "there",
+            **self._build_name_template_data(first_name),
             "match_name": match_name,
             "date": date,
             "time": time,
@@ -307,7 +344,7 @@ class SESEmailService:
             matches_url = f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/volunteer/dashboard"
 
         template_data = {
-            "first_name": first_name if first_name else "there",
+            **self._build_name_template_data(first_name),
             "participant_name": participant_name,
             "matches_url": matches_url,
         }
@@ -354,7 +391,7 @@ class SESEmailService:
             scheduled_calls_url = f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/participant/dashboard"
 
         template_data = {
-            "first_name": first_name if first_name else "there",
+            **self._build_name_template_data(first_name),
             "volunteer_name": volunteer_name,
             "date": date,
             "time": time,
@@ -389,7 +426,13 @@ class SESEmailService:
         if not ranking_url:
             ranking_url = f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/participant/ranking"
 
-        template_data = {"first_name": first_name if first_name else "there", "ranking_url": ranking_url}
+        template_data = {
+            **self._build_name_template_data(
+                first_name,
+                subject_first_word="your" if language == "en" else "votre",
+            ),
+            "ranking_url": ranking_url,
+        }
 
         return self.send_templated_email(to_email, template_name, template_data, source_email)
 
@@ -418,7 +461,13 @@ class SESEmailService:
         if not secondary_app_url:
             secondary_app_url = f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/volunteer/secondary-application"
 
-        template_data = {"first_name": first_name if first_name else "there", "secondary_app_url": secondary_app_url}
+        template_data = {
+            **self._build_name_template_data(
+                first_name,
+                subject_first_word="your" if language == "en" else "votre",
+            ),
+            "secondary_app_url": secondary_app_url,
+        }
 
         return self.send_templated_email(to_email, template_name, template_data, source_email)
 
@@ -441,7 +490,7 @@ class SESEmailService:
         template_name = "RankingFormConfirmationEn" if language == "en" else "RankingFormConfirmationFr"
         source_email = self.source_email_en if language == "en" else self.source_email_fr
 
-        template_data = {"first_name": first_name if first_name else "there"}
+        template_data = self._build_name_template_data(first_name)
 
         return self.send_templated_email(to_email, template_name, template_data, source_email)
 
@@ -464,7 +513,10 @@ class SESEmailService:
         template_name = "RankingApprovedEn" if language == "en" else "RankingApprovedFr"
         source_email = self.source_email_en if language == "en" else self.source_email_fr
 
-        template_data = {"first_name": first_name if first_name else "there"}
+        template_data = self._build_name_template_data(
+            first_name,
+            subject_first_word="you're" if language == "en" else "vous",
+        )
 
         return self.send_templated_email(to_email, template_name, template_data, source_email)
 
@@ -489,7 +541,7 @@ class SESEmailService:
         template_name = "SecondaryAppConfirmationEn" if language == "en" else "SecondaryAppConfirmationFr"
         source_email = self.source_email_en if language == "en" else self.source_email_fr
 
-        template_data = {"first_name": first_name if first_name else "there"}
+        template_data = self._build_name_template_data(first_name)
 
         return self.send_templated_email(to_email, template_name, template_data, source_email)
 
@@ -518,7 +570,13 @@ class SESEmailService:
         if not dashboard_url:
             dashboard_url = f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/volunteer/dashboard"
 
-        template_data = {"first_name": first_name if first_name else "there", "dashboard_url": dashboard_url}
+        template_data = {
+            **self._build_name_template_data(
+                first_name,
+                subject_first_word="your" if language == "en" else "votre",
+            ),
+            "dashboard_url": dashboard_url,
+        }
 
         return self.send_templated_email(to_email, template_name, template_data, source_email)
 
@@ -562,7 +620,7 @@ class SESEmailService:
             dashboard_url = f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/volunteer/dashboard"
 
         template_data = {
-            "first_name": first_name if first_name else "there",
+            **self._build_name_template_data(first_name),
             "participant_name": participant_name,
             "date": date,
             "time": time,
@@ -612,7 +670,7 @@ class SESEmailService:
             request_matches_url = f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/participant/dashboard"
 
         template_data = {
-            "first_name": first_name if first_name else "there",
+            **self._build_name_template_data(first_name),
             "volunteer_name": volunteer_name,
             "date": date,
             "time": time,

--- a/backend/app/utilities/user_name.py
+++ b/backend/app/utilities/user_name.py
@@ -1,5 +1,6 @@
 from app.models import User
 
+
 def resolve_user_first_name(user: User | None) -> str | None:
     if not user:
         return None

--- a/backend/app/utilities/user_name.py
+++ b/backend/app/utilities/user_name.py
@@ -1,0 +1,13 @@
+from app.models import User
+
+def resolve_user_first_name(user: User | None) -> str | None:
+    if not user:
+        return None
+
+    if user.first_name and user.first_name.strip():
+        return user.first_name.strip()
+
+    if user.user_data and user.user_data.first_name and user.user_data.first_name.strip():
+        return user.user_data.first_name.strip()
+
+    return None

--- a/backend/tests/unit/test_match_service.py
+++ b/backend/tests/unit/test_match_service.py
@@ -1637,6 +1637,7 @@ class TestUpdateMatch:
         assert exc_info.value.status_code == 404
         assert "Match" in exc_info.value.detail
 
+
 # ========== VOLUNTEER ACCEPT/DECLINE REQUESTED TIMES TESTS ==========
 
 
@@ -1689,9 +1690,7 @@ class TestVolunteerAcceptRequestedTimes:
             raise
 
     @pytest.mark.asyncio
-    async def test_accept_requested_times_wrong_volunteer_403(
-        self, db_session, requesting_match, another_volunteer
-    ):
+    async def test_accept_requested_times_wrong_volunteer_403(self, db_session, requesting_match, another_volunteer):
         """403 when different volunteer tries to accept"""
         match_service = MatchService(db_session)
         time_block_id = requesting_match.suggested_time_blocks[0].id
@@ -1722,9 +1721,7 @@ class TestVolunteerAcceptRequestedTimes:
         try:
             match_service = MatchService(db_session)
 
-            other_block = TimeBlock(
-                start_time=datetime.now(timezone.utc) + timedelta(days=5)
-            )
+            other_block = TimeBlock(start_time=datetime.now(timezone.utc) + timedelta(days=5))
             db_session.add(other_block)
             db_session.commit()
             db_session.refresh(other_block)
@@ -1749,9 +1746,7 @@ class TestVolunteerAcceptRequestedTimes:
         match_service = MatchService(db_session)
 
         with pytest.raises(HTTPException) as exc_info:
-            await match_service.volunteer_accept_requested_times(
-                99999, 1, acting_volunteer_id=volunteer_user.id
-            )
+            await match_service.volunteer_accept_requested_times(99999, 1, acting_volunteer_id=volunteer_user.id)
 
         assert exc_info.value.status_code == 404
 
@@ -1800,9 +1795,7 @@ class TestVolunteerDeclineRequestedTimes:
             raise
 
     @pytest.mark.asyncio
-    async def test_decline_requested_times_wrong_volunteer_403(
-        self, db_session, requesting_match, another_volunteer
-    ):
+    async def test_decline_requested_times_wrong_volunteer_403(self, db_session, requesting_match, another_volunteer):
         """403 when different volunteer tries to decline"""
         match_service = MatchService(db_session)
 
@@ -1831,12 +1824,9 @@ class TestVolunteerDeclineRequestedTimes:
         match_service = MatchService(db_session)
 
         with pytest.raises(HTTPException) as exc_info:
-            await match_service.volunteer_decline_requested_times(
-                99999, acting_volunteer_id=volunteer_user.id
-            )
+            await match_service.volunteer_decline_requested_times(99999, acting_volunteer_id=volunteer_user.id)
 
         assert exc_info.value.status_code == 404
-
 
     @pytest.mark.asyncio
     async def test_update_match_reassigns_volunteer_resets_suggested_times(

--- a/backend/tests/unit/test_ses_email_service.py
+++ b/backend/tests/unit/test_ses_email_service.py
@@ -178,9 +178,7 @@ class TestSendVerificationEmail:
         )
 
     def test_english_without_name(self, ses_service):
-        ses_service.send_verification_email(
-            "to@example.com", "https://example.com/verify?token=abc", language="en"
-        )
+        ses_service.send_verification_email("to@example.com", "https://example.com/verify?token=abc", language="en")
         assert _render_subject(ses_service._mock_client) == (
             "Confirm your email - First Connection Peer Support Program"
         )
@@ -191,17 +189,13 @@ class TestSendVerificationEmail:
         )
         assert _get_template_name(ses_service._mock_client) == "EmailVerificationFr"
         assert _render_subject(ses_service._mock_client) == (
-            "Marie, confirmation de l'adresse courriel "
-            "\u2013 Programme de soutien par les pairs Premier contact"
+            "Marie, confirmation de l'adresse courriel \u2013 Programme de soutien par les pairs Premier contact"
         )
 
     def test_french_without_name(self, ses_service):
-        ses_service.send_verification_email(
-            "to@example.com", "https://example.com/verify?token=abc", language="fr"
-        )
+        ses_service.send_verification_email("to@example.com", "https://example.com/verify?token=abc", language="fr")
         assert _render_subject(ses_service._mock_client) == (
-            "Confirmation de l'adresse courriel "
-            "\u2013 Programme de soutien par les pairs Premier contact"
+            "Confirmation de l'adresse courriel \u2013 Programme de soutien par les pairs Premier contact"
         )
 
 
@@ -222,9 +216,7 @@ class TestSendPasswordResetEmail:
         )
 
     def test_french(self, ses_service):
-        ses_service.send_password_reset_email(
-            "to@example.com", "https://example.com/reset?token=abc", language="fr"
-        )
+        ses_service.send_password_reset_email("to@example.com", "https://example.com/reset?token=abc", language="fr")
         assert _get_template_name(ses_service._mock_client) == "PasswordResetFr"
 
 
@@ -265,15 +257,13 @@ class TestSendMatchesAvailableEmail:
     def test_french_with_name(self, ses_service):
         ses_service.send_matches_available_email("to@example.com", first_name="Marie", language="fr")
         assert _render_subject(ses_service._mock_client) == (
-            "Marie, nouveaux jumelages "
-            "\u2013 Programme de soutien par les pairs Premier contact"
+            "Marie, nouveaux jumelages \u2013 Programme de soutien par les pairs Premier contact"
         )
 
     def test_french_without_name(self, ses_service):
         ses_service.send_matches_available_email("to@example.com", language="fr")
         assert _render_subject(ses_service._mock_client) == (
-            "Nouveaux jumelages "
-            "\u2013 Programme de soutien par les pairs Premier contact"
+            "Nouveaux jumelages \u2013 Programme de soutien par les pairs Premier contact"
         )
 
     def test_default_matches_url(self, ses_service):
@@ -299,8 +289,7 @@ class TestSendCallScheduledEmail:
         assert data["first_name"] == "Yash"
         assert "/participant/dashboard" in data["scheduled_calls_url"]
         assert _render_subject(ses_service._mock_client) == (
-            "Call confirmed with Jane Doe @ March 22, 2026 10:00 AM EST "
-            "- First Connection Peer Support Program"
+            "Call confirmed with Jane Doe @ March 22, 2026 10:00 AM EST - First Connection Peer Support Program"
         )
 
     def test_french(self, ses_service):
@@ -359,8 +348,7 @@ class TestSendIntakeApprovedVolunteerEmail:
     def test_french_without_name(self, ses_service):
         ses_service.send_intake_approved_volunteer_email("to@example.com", language="fr")
         assert _render_subject(ses_service._mock_client) == (
-            "Votre demande compl\u00e9mentaire est pr\u00eate "
-            "\u2013 Programme de soutien par les pairs Premier contact"
+            "Votre demande compl\u00e9mentaire est pr\u00eate \u2013 Programme de soutien par les pairs Premier contact"
         )
 
 
@@ -403,8 +391,7 @@ class TestSendRankingApprovedEmail:
     def test_french_without_name(self, ses_service):
         ses_service.send_ranking_approved_email("to@example.com", language="fr")
         assert _render_subject(ses_service._mock_client) == (
-            "Vous \u00eates pr\u00eat(e) pour le jumelage "
-            "\u2013 Programme de soutien par les pairs Premier contact"
+            "Vous \u00eates pr\u00eat(e) pour le jumelage \u2013 Programme de soutien par les pairs Premier contact"
         )
 
 
@@ -472,8 +459,7 @@ class TestSendVolunteerAcceptedNewTimesEmail:
         assert data["first_name"] == "Yash"
         assert _get_template_name(ses_service._mock_client) == "VolunteerAcceptedNewTimesEn"
         assert _render_subject(ses_service._mock_client) == (
-            "Jane Doe confirmed your new time @ March 22, 2026 10:00 AM EST "
-            "- First Connection Peer Support Program"
+            "Jane Doe confirmed your new time @ March 22, 2026 10:00 AM EST - First Connection Peer Support Program"
         )
 
 

--- a/backend/tests/unit/test_ses_email_service.py
+++ b/backend/tests/unit/test_ses_email_service.py
@@ -1,0 +1,536 @@
+import json
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.utilities.ses_email_service import SESEmailService
+
+TEMPLATES_PATH = Path(__file__).resolve().parents[2] / "app" / "utilities" / "ses" / "ses_templates.json"
+_TEMPLATES_BY_NAME: dict[str, dict] = {}
+
+
+def _load_templates():
+    if not _TEMPLATES_BY_NAME:
+        with open(TEMPLATES_PATH) as f:
+            for entry in json.load(f):
+                _TEMPLATES_BY_NAME[entry["TemplateName"]] = entry
+
+
+def _render_subject(mock_client) -> str:
+    """Render the full subject line by substituting template data into the SubjectPart from ses_templates.json."""
+    _load_templates()
+    call_kwargs = mock_client.send_templated_email.call_args[1]
+    template_name = call_kwargs["Template"]
+    template_data = json.loads(call_kwargs["TemplateData"])
+    subject_part = _TEMPLATES_BY_NAME[template_name]["SubjectPart"]
+    return re.sub(r"\{\{(\w+)\}\}", lambda m: template_data.get(m.group(1), ""), subject_part)
+
+
+@pytest.fixture
+def ses_service(monkeypatch):
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("AWS_ACCESS_KEY", "fake")
+    monkeypatch.setenv("AWS_SECRET_KEY", "fake")
+    monkeypatch.setenv("SES_SOURCE_EMAIL", "test@example.com")
+
+    with patch("app.utilities.ses_email_service.boto3.client") as mock_boto:
+        mock_client = MagicMock()
+        mock_client.send_templated_email.return_value = {"MessageId": "test-123"}
+        mock_boto.return_value = mock_client
+
+        service = SESEmailService()
+        service._mock_client = mock_client
+        yield service
+
+
+def _get_template_data(mock_client) -> dict:
+    """Extract the parsed template data from the most recent send_templated_email call."""
+    call_kwargs = mock_client.send_templated_email.call_args[1]
+    return json.loads(call_kwargs["TemplateData"])
+
+
+def _get_template_name(mock_client) -> str:
+    call_kwargs = mock_client.send_templated_email.call_args[1]
+    return call_kwargs["Template"]
+
+
+# ---------------------------------------------------------------------------
+# _normalize_first_name
+# ---------------------------------------------------------------------------
+class TestNormalizeFirstName:
+    def test_none(self, ses_service):
+        assert ses_service._normalize_first_name(None) is None
+
+    def test_empty(self, ses_service):
+        assert ses_service._normalize_first_name("") is None
+
+    def test_whitespace_only(self, ses_service):
+        assert ses_service._normalize_first_name("   ") is None
+
+    def test_normal_name(self, ses_service):
+        assert ses_service._normalize_first_name("Yash") == "Yash"
+
+    def test_strips_whitespace(self, ses_service):
+        assert ses_service._normalize_first_name("  Yash  ") == "Yash"
+
+
+# ---------------------------------------------------------------------------
+# _build_name_template_data
+# ---------------------------------------------------------------------------
+class TestBuildNameTemplateData:
+    def test_with_name(self, ses_service):
+        result = ses_service._build_name_template_data("Yash")
+        assert result["first_name"] == "Yash"
+        assert result["subject_prefix"] == "Yash, "
+        assert "subject_first_word" not in result
+
+    def test_without_name(self, ses_service):
+        result = ses_service._build_name_template_data(None)
+        assert result["first_name"] == "there"
+        assert result["subject_prefix"] == ""
+
+    def test_empty_string_name(self, ses_service):
+        result = ses_service._build_name_template_data("")
+        assert result["first_name"] == "there"
+        assert result["subject_prefix"] == ""
+
+    def test_whitespace_name(self, ses_service):
+        result = ses_service._build_name_template_data("   ")
+        assert result["first_name"] == "there"
+        assert result["subject_prefix"] == ""
+
+    def test_subject_first_word_with_name(self, ses_service):
+        result = ses_service._build_name_template_data("Yash", subject_first_word="confirm")
+        assert result["subject_first_word"] == "confirm"
+
+    def test_subject_first_word_capitalized_without_name(self, ses_service):
+        result = ses_service._build_name_template_data(None, subject_first_word="confirm")
+        assert result["subject_first_word"] == "Confirm"
+
+    def test_subject_first_word_already_capitalized_without_name(self, ses_service):
+        result = ses_service._build_name_template_data(None, subject_first_word="Your")
+        assert result["subject_first_word"] == "Your"
+
+    def test_subject_first_word_with_contraction(self, ses_service):
+        result = ses_service._build_name_template_data(None, subject_first_word="you're")
+        assert result["subject_first_word"] == "You're"
+
+    def test_subject_first_word_with_name_stays_lowercase(self, ses_service):
+        result = ses_service._build_name_template_data("Yash", subject_first_word="you're")
+        assert result["subject_first_word"] == "you're"
+
+    def test_subject_first_word_french_without_name(self, ses_service):
+        result = ses_service._build_name_template_data(None, subject_first_word="votre")
+        assert result["subject_first_word"] == "Votre"
+
+    def test_subject_first_word_none_not_included(self, ses_service):
+        result = ses_service._build_name_template_data("Yash", subject_first_word=None)
+        assert "subject_first_word" not in result
+
+    def test_subject_first_word_empty_not_included(self, ses_service):
+        result = ses_service._build_name_template_data("Yash", subject_first_word="")
+        assert "subject_first_word" not in result
+
+
+# ---------------------------------------------------------------------------
+# send_templated_email
+# ---------------------------------------------------------------------------
+class TestSendTemplatedEmail:
+    def test_returns_true_on_success(self, ses_service):
+        result = ses_service.send_templated_email("to@example.com", "TestTemplate", {"key": "value"})
+        assert result is True
+        ses_service._mock_client.send_templated_email.assert_called_once()
+
+    def test_returns_false_when_client_is_none(self, ses_service):
+        ses_service.ses_client = None
+        result = ses_service.send_templated_email("to@example.com", "TestTemplate", {"key": "value"})
+        assert result is False
+
+    def test_passes_correct_args(self, ses_service):
+        ses_service.send_templated_email("to@example.com", "MyTemplate", {"k": "v"}, "from@example.com")
+        call_kwargs = ses_service._mock_client.send_templated_email.call_args[1]
+        assert call_kwargs["Source"] == "from@example.com"
+        assert call_kwargs["Destination"] == {"ToAddresses": ["to@example.com"]}
+        assert call_kwargs["Template"] == "MyTemplate"
+        assert json.loads(call_kwargs["TemplateData"]) == {"k": "v"}
+
+    def test_uses_default_source_email(self, ses_service):
+        ses_service.send_templated_email("to@example.com", "T", {})
+        call_kwargs = ses_service._mock_client.send_templated_email.call_args[1]
+        assert call_kwargs["Source"] == ses_service.source_email
+
+
+# ---------------------------------------------------------------------------
+# send_verification_email
+# ---------------------------------------------------------------------------
+class TestSendVerificationEmail:
+    def test_english_with_name(self, ses_service):
+        ses_service.send_verification_email(
+            "to@example.com", "https://example.com/verify?token=abc", first_name="Yash", language="en"
+        )
+        data = _get_template_data(ses_service._mock_client)
+        assert data["verification_link"] == "https://example.com/verify?token=abc"
+        assert _get_template_name(ses_service._mock_client) == "EmailVerificationEn"
+        assert _render_subject(ses_service._mock_client) == (
+            "Yash, confirm your email - First Connection Peer Support Program"
+        )
+
+    def test_english_without_name(self, ses_service):
+        ses_service.send_verification_email(
+            "to@example.com", "https://example.com/verify?token=abc", language="en"
+        )
+        assert _render_subject(ses_service._mock_client) == (
+            "Confirm your email - First Connection Peer Support Program"
+        )
+
+    def test_french_with_name(self, ses_service):
+        ses_service.send_verification_email(
+            "to@example.com", "https://example.com/verify?token=abc", first_name="Marie", language="fr"
+        )
+        assert _get_template_name(ses_service._mock_client) == "EmailVerificationFr"
+        assert _render_subject(ses_service._mock_client) == (
+            "Marie, confirmation de l'adresse courriel "
+            "\u2013 Programme de soutien par les pairs Premier contact"
+        )
+
+    def test_french_without_name(self, ses_service):
+        ses_service.send_verification_email(
+            "to@example.com", "https://example.com/verify?token=abc", language="fr"
+        )
+        assert _render_subject(ses_service._mock_client) == (
+            "Confirmation de l'adresse courriel "
+            "\u2013 Programme de soutien par les pairs Premier contact"
+        )
+
+
+# ---------------------------------------------------------------------------
+# send_password_reset_email
+# ---------------------------------------------------------------------------
+class TestSendPasswordResetEmail:
+    def test_english(self, ses_service):
+        ses_service.send_password_reset_email(
+            "to@example.com", "https://example.com/reset?token=abc", first_name="Yash"
+        )
+        data = _get_template_data(ses_service._mock_client)
+        assert data["first_name"] == "Yash"
+        assert data["reset_link"] == "https://example.com/reset?token=abc"
+        assert _get_template_name(ses_service._mock_client) == "PasswordResetEn"
+        assert _render_subject(ses_service._mock_client) == (
+            "Reset Your Password - First Connection Peer Support Program"
+        )
+
+    def test_french(self, ses_service):
+        ses_service.send_password_reset_email(
+            "to@example.com", "https://example.com/reset?token=abc", language="fr"
+        )
+        assert _get_template_name(ses_service._mock_client) == "PasswordResetFr"
+
+
+# ---------------------------------------------------------------------------
+# send_intake_form_confirmation_email
+# ---------------------------------------------------------------------------
+class TestSendIntakeFormConfirmationEmail:
+    def test_with_name(self, ses_service):
+        ses_service.send_intake_form_confirmation_email("to@example.com", first_name="Yash")
+        data = _get_template_data(ses_service._mock_client)
+        assert data["first_name"] == "Yash"
+        assert _render_subject(ses_service._mock_client) == (
+            "We received your intake form - First Connection Peer Support Program"
+        )
+
+    def test_without_name(self, ses_service):
+        ses_service.send_intake_form_confirmation_email("to@example.com")
+        data = _get_template_data(ses_service._mock_client)
+        assert data["first_name"] == "there"
+
+
+# ---------------------------------------------------------------------------
+# send_matches_available_email
+# ---------------------------------------------------------------------------
+class TestSendMatchesAvailableEmail:
+    def test_english_with_name(self, ses_service):
+        ses_service.send_matches_available_email("to@example.com", first_name="Yash", language="en")
+        assert _render_subject(ses_service._mock_client) == (
+            "Yash, you have new matches - First Connection Peer Support Program"
+        )
+
+    def test_english_without_name(self, ses_service):
+        ses_service.send_matches_available_email("to@example.com", language="en")
+        assert _render_subject(ses_service._mock_client) == (
+            "You have new matches - First Connection Peer Support Program"
+        )
+
+    def test_french_with_name(self, ses_service):
+        ses_service.send_matches_available_email("to@example.com", first_name="Marie", language="fr")
+        assert _render_subject(ses_service._mock_client) == (
+            "Marie, nouveaux jumelages "
+            "\u2013 Programme de soutien par les pairs Premier contact"
+        )
+
+    def test_french_without_name(self, ses_service):
+        ses_service.send_matches_available_email("to@example.com", language="fr")
+        assert _render_subject(ses_service._mock_client) == (
+            "Nouveaux jumelages "
+            "\u2013 Programme de soutien par les pairs Premier contact"
+        )
+
+    def test_default_matches_url(self, ses_service):
+        ses_service.send_matches_available_email("to@example.com")
+        data = _get_template_data(ses_service._mock_client)
+        assert "/participant/dashboard" in data["matches_url"]
+
+
+# ---------------------------------------------------------------------------
+# send_call_scheduled_email
+# ---------------------------------------------------------------------------
+class TestSendCallScheduledEmail:
+    def test_english(self, ses_service):
+        ses_service.send_call_scheduled_email(
+            "to@example.com",
+            match_name="Jane Doe",
+            date="March 22, 2026",
+            time="10:00 AM",
+            timezone="EST",
+            first_name="Yash",
+        )
+        data = _get_template_data(ses_service._mock_client)
+        assert data["first_name"] == "Yash"
+        assert "/participant/dashboard" in data["scheduled_calls_url"]
+        assert _render_subject(ses_service._mock_client) == (
+            "Call confirmed with Jane Doe @ March 22, 2026 10:00 AM EST "
+            "- First Connection Peer Support Program"
+        )
+
+    def test_french(self, ses_service):
+        ses_service.send_call_scheduled_email(
+            "to@example.com",
+            match_name="Marie Dupont",
+            date="22 mars 2026",
+            time="10h00",
+            timezone="HNE",
+            language="fr",
+        )
+        assert _render_subject(ses_service._mock_client) == (
+            "Confirmation de l'appel avec Marie Dupont le 22 mars 2026 "
+            "\u00e0 10h00 HNE "
+            "\u2013 Programme de soutien par les pairs Premier contact"
+        )
+
+
+# ---------------------------------------------------------------------------
+# send_intake_approved_participant_email
+# ---------------------------------------------------------------------------
+class TestSendIntakeApprovedParticipantEmail:
+    def test_english_with_name(self, ses_service):
+        ses_service.send_intake_approved_participant_email("to@example.com", first_name="Yash", language="en")
+        data = _get_template_data(ses_service._mock_client)
+        assert "/participant/ranking" in data["ranking_url"]
+        assert _render_subject(ses_service._mock_client) == (
+            "Yash, your matching preferences form is ready - First Connection Peer Support Program"
+        )
+
+    def test_english_without_name(self, ses_service):
+        ses_service.send_intake_approved_participant_email("to@example.com", language="en")
+        assert _render_subject(ses_service._mock_client) == (
+            "Your matching preferences form is ready - First Connection Peer Support Program"
+        )
+
+
+# ---------------------------------------------------------------------------
+# send_intake_approved_volunteer_email
+# ---------------------------------------------------------------------------
+class TestSendIntakeApprovedVolunteerEmail:
+    def test_english_with_name(self, ses_service):
+        ses_service.send_intake_approved_volunteer_email("to@example.com", first_name="Yash", language="en")
+        data = _get_template_data(ses_service._mock_client)
+        assert "/volunteer/secondary-application" in data["secondary_app_url"]
+        assert _render_subject(ses_service._mock_client) == (
+            "Yash, your secondary application is ready - First Connection Peer Support Program"
+        )
+
+    def test_english_without_name(self, ses_service):
+        ses_service.send_intake_approved_volunteer_email("to@example.com", language="en")
+        assert _render_subject(ses_service._mock_client) == (
+            "Your secondary application is ready - First Connection Peer Support Program"
+        )
+
+    def test_french_without_name(self, ses_service):
+        ses_service.send_intake_approved_volunteer_email("to@example.com", language="fr")
+        assert _render_subject(ses_service._mock_client) == (
+            "Votre demande compl\u00e9mentaire est pr\u00eate "
+            "\u2013 Programme de soutien par les pairs Premier contact"
+        )
+
+
+# ---------------------------------------------------------------------------
+# send_ranking_form_confirmation_email
+# ---------------------------------------------------------------------------
+class TestSendRankingFormConfirmationEmail:
+    def test_with_name(self, ses_service):
+        ses_service.send_ranking_form_confirmation_email("to@example.com", first_name="Yash")
+        data = _get_template_data(ses_service._mock_client)
+        assert data["first_name"] == "Yash"
+        assert _render_subject(ses_service._mock_client) == (
+            "We received your matching preferences - First Connection Peer Support Program"
+        )
+
+
+# ---------------------------------------------------------------------------
+# send_ranking_approved_email
+# ---------------------------------------------------------------------------
+class TestSendRankingApprovedEmail:
+    def test_english_with_name(self, ses_service):
+        ses_service.send_ranking_approved_email("to@example.com", first_name="Yash", language="en")
+        assert _render_subject(ses_service._mock_client) == (
+            "Yash, you're ready for matching - First Connection Peer Support Program"
+        )
+
+    def test_english_without_name(self, ses_service):
+        ses_service.send_ranking_approved_email("to@example.com", language="en")
+        assert _render_subject(ses_service._mock_client) == (
+            "You're ready for matching - First Connection Peer Support Program"
+        )
+
+    def test_french_with_name(self, ses_service):
+        ses_service.send_ranking_approved_email("to@example.com", first_name="Marie", language="fr")
+        assert _render_subject(ses_service._mock_client) == (
+            "Marie, vous \u00eates pr\u00eat(e) pour le jumelage "
+            "\u2013 Programme de soutien par les pairs Premier contact"
+        )
+
+    def test_french_without_name(self, ses_service):
+        ses_service.send_ranking_approved_email("to@example.com", language="fr")
+        assert _render_subject(ses_service._mock_client) == (
+            "Vous \u00eates pr\u00eat(e) pour le jumelage "
+            "\u2013 Programme de soutien par les pairs Premier contact"
+        )
+
+
+# ---------------------------------------------------------------------------
+# send_secondary_app_confirmation_email
+# ---------------------------------------------------------------------------
+class TestSendSecondaryAppConfirmationEmail:
+    def test_with_name(self, ses_service):
+        ses_service.send_secondary_app_confirmation_email("to@example.com", first_name="Yash")
+        data = _get_template_data(ses_service._mock_client)
+        assert data["first_name"] == "Yash"
+        assert _render_subject(ses_service._mock_client) == (
+            "We received your volunteer application - First Connection Peer Support Program"
+        )
+
+
+# ---------------------------------------------------------------------------
+# send_secondary_app_approved_email
+# ---------------------------------------------------------------------------
+class TestSendSecondaryAppApprovedEmail:
+    def test_english_with_name(self, ses_service):
+        ses_service.send_secondary_app_approved_email("to@example.com", first_name="Yash", language="en")
+        data = _get_template_data(ses_service._mock_client)
+        assert "/volunteer/dashboard" in data["dashboard_url"]
+        assert _render_subject(ses_service._mock_client) == (
+            "Yash, your volunteer profile is complete - First Connection Peer Support Program"
+        )
+
+    def test_english_without_name(self, ses_service):
+        ses_service.send_secondary_app_approved_email("to@example.com", language="en")
+        assert _render_subject(ses_service._mock_client) == (
+            "Your volunteer profile is complete - First Connection Peer Support Program"
+        )
+
+
+# ---------------------------------------------------------------------------
+# send_participant_requested_new_times_email
+# ---------------------------------------------------------------------------
+class TestSendParticipantRequestedNewTimesEmail:
+    def test_english(self, ses_service):
+        ses_service.send_participant_requested_new_times_email(
+            "to@example.com", participant_name="Jane Doe", first_name="Yash"
+        )
+        data = _get_template_data(ses_service._mock_client)
+        assert data["first_name"] == "Yash"
+        assert _render_subject(ses_service._mock_client) == (
+            "Jane Doe requested new times - First Connection Peer Support Program"
+        )
+
+
+# ---------------------------------------------------------------------------
+# send_volunteer_accepted_new_times_email
+# ---------------------------------------------------------------------------
+class TestSendVolunteerAcceptedNewTimesEmail:
+    def test_english(self, ses_service):
+        ses_service.send_volunteer_accepted_new_times_email(
+            "to@example.com",
+            volunteer_name="Jane Doe",
+            date="March 22, 2026",
+            time="10:00 AM",
+            timezone="EST",
+            first_name="Yash",
+        )
+        data = _get_template_data(ses_service._mock_client)
+        assert data["first_name"] == "Yash"
+        assert _get_template_name(ses_service._mock_client) == "VolunteerAcceptedNewTimesEn"
+        assert _render_subject(ses_service._mock_client) == (
+            "Jane Doe confirmed your new time @ March 22, 2026 10:00 AM EST "
+            "- First Connection Peer Support Program"
+        )
+
+
+# ---------------------------------------------------------------------------
+# send_participant_cancelled_email
+# ---------------------------------------------------------------------------
+class TestSendParticipantCancelledEmail:
+    def test_english(self, ses_service):
+        ses_service.send_participant_cancelled_email(
+            "to@example.com",
+            participant_name="Jane Doe",
+            date="March 22, 2026",
+            time="10:00 AM",
+            timezone="EST",
+            first_name="Yash",
+        )
+        data = _get_template_data(ses_service._mock_client)
+        assert data["first_name"] == "Yash"
+        assert "/volunteer/dashboard" in data["dashboard_url"]
+        assert _render_subject(ses_service._mock_client) == (
+            "Call cancelled by Jane Doe - First Connection Peer Support Program"
+        )
+
+
+# ---------------------------------------------------------------------------
+# send_volunteer_cancelled_email
+# ---------------------------------------------------------------------------
+class TestSendVolunteerCancelledEmail:
+    def test_english(self, ses_service):
+        ses_service.send_volunteer_cancelled_email(
+            "to@example.com",
+            volunteer_name="Jane Doe",
+            date="March 22, 2026",
+            time="10:00 AM",
+            timezone="EST",
+            first_name="Yash",
+        )
+        data = _get_template_data(ses_service._mock_client)
+        assert data["first_name"] == "Yash"
+        assert "/participant/dashboard" in data["request_matches_url"]
+        assert _render_subject(ses_service._mock_client) == (
+            "Call cancelled by Jane Doe - First Connection Peer Support Program"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Language fallback
+# ---------------------------------------------------------------------------
+class TestLanguageFallback:
+    def test_invalid_language_defaults_to_english(self, ses_service):
+        ses_service.send_intake_form_confirmation_email("to@example.com", language="de")
+        assert _get_template_name(ses_service._mock_client) == "IntakeFormConfirmationEn"
+
+    def test_none_language_defaults_to_english(self, ses_service):
+        ses_service.send_intake_form_confirmation_email("to@example.com", language=None)
+        assert _get_template_name(ses_service._mock_client) == "IntakeFormConfirmationEn"
+
+    def test_case_insensitive_language(self, ses_service):
+        ses_service.send_intake_form_confirmation_email("to@example.com", language="FR")
+        assert _get_template_name(ses_service._mock_client) == "IntakeFormConfirmationFr"

--- a/backend/tests/unit/test_user_name.py
+++ b/backend/tests/unit/test_user_name.py
@@ -1,7 +1,5 @@
 from unittest.mock import MagicMock
 
-import pytest
-
 from app.utilities.user_name import resolve_user_first_name
 
 

--- a/backend/tests/unit/test_user_name.py
+++ b/backend/tests/unit/test_user_name.py
@@ -1,0 +1,67 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.utilities.user_name import resolve_user_first_name
+
+
+def _make_user(first_name=None, user_data_first_name=None):
+    user = MagicMock()
+    user.first_name = first_name
+
+    if user_data_first_name is not None:
+        user.user_data = MagicMock()
+        user.user_data.first_name = user_data_first_name
+    else:
+        user.user_data = None
+
+    return user
+
+
+class TestResolveUserFirstName:
+    def test_returns_none_for_none_user(self):
+        assert resolve_user_first_name(None) is None
+
+    def test_returns_user_first_name(self):
+        user = _make_user(first_name="Yash")
+        assert resolve_user_first_name(user) == "Yash"
+
+    def test_strips_user_first_name(self):
+        user = _make_user(first_name="  Yash  ")
+        assert resolve_user_first_name(user) == "Yash"
+
+    def test_falls_back_to_user_data_first_name(self):
+        user = _make_user(first_name=None, user_data_first_name="Marie")
+        assert resolve_user_first_name(user) == "Marie"
+
+    def test_falls_back_when_user_first_name_is_empty(self):
+        user = _make_user(first_name="", user_data_first_name="Marie")
+        assert resolve_user_first_name(user) == "Marie"
+
+    def test_falls_back_when_user_first_name_is_whitespace(self):
+        user = _make_user(first_name="   ", user_data_first_name="Marie")
+        assert resolve_user_first_name(user) == "Marie"
+
+    def test_strips_user_data_first_name(self):
+        user = _make_user(first_name=None, user_data_first_name="  Marie  ")
+        assert resolve_user_first_name(user) == "Marie"
+
+    def test_returns_none_when_both_empty(self):
+        user = _make_user(first_name="", user_data_first_name="")
+        assert resolve_user_first_name(user) is None
+
+    def test_returns_none_when_both_whitespace(self):
+        user = _make_user(first_name="   ", user_data_first_name="   ")
+        assert resolve_user_first_name(user) is None
+
+    def test_returns_none_when_both_none(self):
+        user = _make_user(first_name=None, user_data_first_name=None)
+        assert resolve_user_first_name(user) is None
+
+    def test_returns_none_when_no_user_data_relation(self):
+        user = _make_user(first_name=None)
+        assert resolve_user_first_name(user) is None
+
+    def test_prefers_user_first_name_over_user_data(self):
+        user = _make_user(first_name="Yash", user_data_first_name="Marie")
+        assert resolve_user_first_name(user) == "Yash"


### PR DESCRIPTION
## Summary

- **Fix "there" in email subjects**: When a user has no first name on file, subjects were rendering as `"there, confirm your email..."`. Now subjects omit the name entirely (`"Confirm your email..."`) while the body greeting remains `"Hi there"`. This is powered by new `subject_prefix` / `subject_first_word` template variables with conditional capitalization.
- **Consolidate name resolution**: The `resolve_user_first_name` helper (User.first_name → UserData.first_name fallback) was duplicated across six files. Extracted into a single shared utility at `app/utilities/user_name.py`.
- **Add volunteer-accepts-new-times emails**: When a volunteer accepts a participant's suggested time slot, both parties now receive email notifications — a "volunteer accepted new times" email to the participant and a "call scheduled" confirmation to the volunteer.
- **Add unit tests**: 68 new tests covering `resolve_user_first_name`, `_build_name_template_data`, and every `SESEmailService.send_*` method. Tests render full subject lines against `ses_templates.json` to catch template/data mismatches.

## Test plan

- [x] `pdm run pytest tests/unit/test_user_name.py tests/unit/test_ses_email_service.py` — 68 tests passing
- [ ] Verify email subjects render correctly in staging (SES templates already updated via `update_ses_templates.py`)
- [ ] Trigger a volunteer-accepts-new-times flow and confirm both participant and volunteer receive the correct emails

Made with [Cursor](https://cursor.com)